### PR TITLE
Fix infinite loop in distortion profile watcher

### DIFF
--- a/CustomHeadsetOpenVR/src/Config/ConfigLoader.cpp
+++ b/CustomHeadsetOpenVR/src/Config/ConfigLoader.cpp
@@ -244,6 +244,7 @@ void ConfigLoader::WatcherThreadDistortions(){
 				ParseConfig();
 				break;
 			}
+			pNotify = (FILE_NOTIFY_INFORMATION*)((char*)pNotify + pNotify->NextEntryOffset);
 		}while(pNotify->NextEntryOffset != 0);
 		std::this_thread::sleep_for(std::chrono::milliseconds(40));
 	}


### PR DESCRIPTION
If a file change didn't match the change detection criteria, then the
watcher thread would get stuck in an infinite loop and eat CPU usage.