### PR TITLE
Add Hidden Area Mesh functionality

### DIFF
--- a/CustomHeadsetGUI/src/app/pages/basic-settings/basic-settings.component.html
+++ b/CustomHeadsetGUI/src/app/pages/basic-settings/basic-settings.component.html
@@ -146,7 +146,108 @@
             </mat-slider>
         </div>
     </div>
+    @if(hiddenArea){
+        <div class="field">
+            <div class="title">
+                <span i18n class="required">Enable Hidden Area Meshes</span>
+                <app-reset-button [canReset]="hiddenArea.enable!=defaults?.hiddenArea?.enable"
+                (resetClick)="resetHiddenAreaOption('enable')"></app-reset-button>
+            </div>
+            <div class="control">
+                <mat-slide-toggle [(ngModel)]="hiddenArea.enable"
+                (ngModelChange)="saveConfigSettings()"></mat-slide-toggle>
+            </div>
+        </div>
+    @if(hiddenArea.enable){
+    <div class="field">
+        <div class="section-title">
+            <span i18n>Hidden Area Mesh Settings</span>
+        </div>
+    </div>
 
+    <div class="field">
+        <div class="title">
+            <span i18n class="required">Test Mode</span>
+            <app-reset-button [canReset]="hiddenArea.testMode!=defaults?.hiddenArea?.testMode"
+                (resetClick)="resetHiddenAreaOption('testMode')"></app-reset-button>
+        </div>
+        <div class="control">
+            <mat-slide-toggle [(ngModel)]="hiddenArea.testMode"
+                (ngModelChange)="saveConfigSettings()"></mat-slide-toggle>
+        </div>
+    </div>
+    <div class="field">
+        <div class="title">
+            <span i18n class="required">Mesh Detail</span>
+            <app-reset-button [canReset]="hiddenArea.detailLevel!=defaults?.hiddenArea?.detailLevel"
+                (resetClick)="resetHiddenAreaOption('detailLevel')"></app-reset-button>
+        </div>
+        <div class="control">
+            <input matInput [(ngModel)]="hiddenArea.detailLevel" step="1" (ngModelChange)="saveConfigSettings()"
+                type="number">
+            <mat-slider max="32" min="1" step="1">
+                <input matSliderThumb [(ngModel)]="hiddenArea.detailLevel" (ngModelChange)="saveConfigSettings()">
+            </mat-slider>
+        </div>
+    </div>
+    <div class="field">
+        <div class="title">
+            <span i18n class="required">Radius Top Outer</span>
+            <app-reset-button [canReset]="hiddenArea.radiusTopOuter!=defaults?.hiddenArea?.radiusTopOuter"
+                (resetClick)="resetHiddenAreaOption('radiusTopOuter')"></app-reset-button>
+        </div>
+        <div class="control">
+            <input matInput [(ngModel)]="hiddenArea.radiusTopOuter" step="1" (ngModelChange)="saveConfigSettings()"
+                type="number">
+            <mat-slider max="0.5" min="0.0" step="0.05">
+                <input matSliderThumb [(ngModel)]="hiddenArea.radiusTopOuter" (ngModelChange)="saveConfigSettings()">
+            </mat-slider>
+        </div>
+    </div>
+    <div class="field">
+        <div class="title">
+            <span i18n class="required">Radius Top Inner</span>
+            <app-reset-button [canReset]="hiddenArea.radiusTopInner!=defaults?.hiddenArea?.radiusTopInner"
+                (resetClick)="resetHiddenAreaOption('radiusTopInner')"></app-reset-button>
+        </div>
+        <div class="control">
+            <input matInput [(ngModel)]="hiddenArea.radiusTopInner" step="1" (ngModelChange)="saveConfigSettings()"
+                type="number">
+            <mat-slider max="0.5" min="0.0" step="0.05">
+                <input matSliderThumb [(ngModel)]="hiddenArea.radiusTopInner" (ngModelChange)="saveConfigSettings()">
+            </mat-slider>
+        </div>
+    </div>
+    <div class="field">
+        <div class="title">
+            <span i18n class="required">Radius Bottom Inner</span>
+            <app-reset-button [canReset]="hiddenArea.radiusBottomInner!=defaults?.hiddenArea?.radiusBottomInner"
+                (resetClick)="resetHiddenAreaOption('radiusBottomInner')"></app-reset-button>
+        </div>
+        <div class="control">
+            <input matInput [(ngModel)]="hiddenArea.radiusBottomInner" step="1" (ngModelChange)="saveConfigSettings()"
+                type="number">
+            <mat-slider max="0.5" min="0.0" step="0.05">
+                <input matSliderThumb [(ngModel)]="hiddenArea.radiusBottomInner" (ngModelChange)="saveConfigSettings()">
+            </mat-slider>
+        </div>
+    </div>
+    <div class="field">
+        <div class="title">
+            <span i18n class="required">Radius Bottom Outer</span>
+            <app-reset-button [canReset]="hiddenArea.radiusBottomOuter!=defaults?.hiddenArea?.radiusBottomOuter"
+                (resetClick)="resetHiddenAreaOption('radiusBottomOuter')"></app-reset-button>
+        </div>
+        <div class="control">
+            <input matInput [(ngModel)]="hiddenArea.radiusBottomOuter" step="1" (ngModelChange)="saveConfigSettings()"
+                type="number">
+            <mat-slider max="0.5" min="0.0" step="0.05">
+                <input matSliderThumb [(ngModel)]="hiddenArea.radiusBottomOuter" (ngModelChange)="saveConfigSettings()">
+            </mat-slider>
+        </div>
+    </div>
+    }
+    }
     @if(advanceMode()){
 
     <div class="field">

--- a/CustomHeadsetGUI/src/app/pages/basic-settings/basic-settings.component.ts
+++ b/CustomHeadsetGUI/src/app/pages/basic-settings/basic-settings.component.ts
@@ -9,7 +9,7 @@ import { MatSlideToggleModule } from '@angular/material/slide-toggle'
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { DistortionProfileEntry, DriverSettingService } from '../../services/driver-setting.service';
 import { CommonModule } from '@angular/common';
-import { Settings, MeganeX8KConfig, DriverInfo } from '../../services/JsonFileDefines';
+import { Settings, MeganeX8KConfig, DriverInfo, HiddenAreaMeshConfig } from '../../services/JsonFileDefines';
 import { FormsModule } from '@angular/forms';
 import { AppSettingService } from '../../services/app-setting.service';
 import { DriverInfoService } from '../../services/driver-info.service';
@@ -40,6 +40,7 @@ import { SystemDiagnosticService } from '../../services/system-diagnostic.servic
 export class BasicSettingsComponent {
     profiles: DistortionProfileEntry[] = []
     settings?: MeganeX8KConfig
+    hiddenArea?: HiddenAreaMeshConfig
     config?: Settings;
     defaults?: MeganeX8KConfig;
     subpixelShiftOptions = [0, 0.33];
@@ -62,6 +63,7 @@ export class BasicSettingsComponent {
             const config = dss.values();
             this.config = config;
             this.settings = config?.meganeX8K;
+            this.hiddenArea = config?.meganeX8K?.hiddenArea
             this.resolutionModel = this.settings?.resolutionX;
         });
 
@@ -102,6 +104,12 @@ export class BasicSettingsComponent {
     resetOption(key: keyof MeganeX8KConfig) {
         if (this.settings && this.defaults) {
             (this.settings as any)[key] = this.defaults[key];
+            this.saveConfigSettings()
+        }
+    }
+    resetHiddenAreaOption(key: keyof HiddenAreaMeshConfig) {
+        if (this.hiddenArea && this.defaults && this.defaults.hiddenArea) {
+            (this.hiddenArea as any)[key] = this.defaults.hiddenArea[key];
             this.saveConfigSettings()
         }
     }

--- a/CustomHeadsetGUI/src/app/services/JsonFileDefines.ts
+++ b/CustomHeadsetGUI/src/app/services/JsonFileDefines.ts
@@ -11,6 +11,39 @@ export type Settings = {
   watchDistortionProfiles: boolean,
   meganeX8K: MeganeX8KConfig
 }
+
+export type HiddenAreaMeshConfig = {
+  /**
+   * If hidden area meshes should be used.
+   */
+  enable: boolean;
+  /**
+   * "Inverts" the hidden area meshes and increases the black level.
+   * This makes it easy to see how large the hidden are mesh is.
+   */
+  testMode: boolean;
+  /**
+   * How many points should be used for each rounded corner.
+   */
+  detailLevel: number;
+  /**
+   * Top outer corner radius, as a fraction the cropped display area.
+   */
+  radiusTopOuter: number;
+  /**
+   * Top inner corner radius, as a fraction the cropped display area.
+   */
+  radiusTopInner: number;
+  /**
+   * Bottom inner corner radius, as a fraction the cropped display area.
+   */
+  radiusBottomInner: number;
+  /**
+   * Bottom outer corner radius, as a fraction the cropped display area.
+   */
+  radiusBottomOuter: number;
+};
+
 export type MeganeX8KConfig = {
   /**
    * if the MeganeX superlight 8K should be shimmed by this driver
@@ -62,6 +95,8 @@ export type MeganeX8KConfig = {
   renderResolutionMultiplierX: number;
 
   renderResolutionMultiplierY: number;
+
+  hiddenArea: HiddenAreaMeshConfig;
 };
 
 export type AppSetting = {

--- a/CustomHeadsetOpenVR/CustomHeadsetOpenVR.vcxproj
+++ b/CustomHeadsetOpenVR/CustomHeadsetOpenVR.vcxproj
@@ -28,6 +28,7 @@
     <ClInclude Include="src\Driver\Hooking\Hooking.h" />
     <ClInclude Include="src\Driver\Hooking\InterfaceHookInjector.h" />
     <ClInclude Include="src\Headsets\MeganeX8K.h" />
+    <ClInclude Include="src\HiddenArea\HiddenArea.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\Config\Config.cpp" />
@@ -41,6 +42,7 @@
     <ClCompile Include="src\Driver\Hooking\Hooking.cpp" />
     <ClCompile Include="src\Driver\Hooking\InterfaceHookInjector.cpp" />
     <ClCompile Include="src\Headsets\MeganeX8K.cpp" />
+    <ClCompile Include="src\HiddenArea\HiddenArea.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ThirdParty\minhook\build\VC17\libMinHook.vcxproj">

--- a/CustomHeadsetOpenVR/CustomHeadsetOpenVR.vcxproj.filters
+++ b/CustomHeadsetOpenVR/CustomHeadsetOpenVR.vcxproj.filters
@@ -42,6 +42,9 @@
     <ClInclude Include="src\Headsets\MeganeX8K.h">
       <Filter>Source Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\HiddenArea\HiddenArea.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\Driver\DeviceProvider.cpp">
@@ -75,6 +78,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\Distortion\DistortionProfileConstructor.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\HiddenArea\HiddenArea.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/CustomHeadsetOpenVR/src/Config/Config.h
+++ b/CustomHeadsetOpenVR/src/Config/Config.h
@@ -2,7 +2,25 @@
 #include <string>
 #include <vector>
 #include <mutex>
+#include <tuple>
 
+struct HiddenAreaMeshConfig {
+	bool enable = false;
+	bool testMode = false;
+	int detailLevel = 16;
+	double radiusTopOuter = 0.25;
+	double radiusTopInner = 0.25;
+	double radiusBottomInner = 0.25;
+	double radiusBottomOuter = 0.25;
+
+	constexpr bool operator==(const HiddenAreaMeshConfig& other) const {
+		return std::tie(this->enable, this->testMode, this->detailLevel, this->radiusTopOuter, this->radiusTopInner, this->radiusBottomInner, this->radiusBottomOuter) ==
+		       std::tie(other.enable, other.testMode, other.detailLevel, other.radiusTopOuter, other.radiusTopInner, other.radiusBottomInner, other.radiusBottomOuter);
+	}
+	constexpr bool operator!=(const HiddenAreaMeshConfig& other) const {
+		return !(this->operator==(other));
+	}
+};
 
 class Config{
 public:
@@ -38,6 +56,8 @@ public:
 		double renderResolutionMultiplierX = 1.0;
 		// multiply 100% render resolution height
 		double renderResolutionMultiplierY = 1.0;
+		// Config struct for the hidden area mesh
+		HiddenAreaMeshConfig hiddenArea;
 	};
 	// config for the MeganeX superlight 8K
 	MeganeX8KConfig meganeX8K;

--- a/CustomHeadsetOpenVR/src/Config/ConfigLoader.cpp
+++ b/CustomHeadsetOpenVR/src/Config/ConfigLoader.cpp
@@ -83,6 +83,16 @@ void ConfigLoader::ParseConfig(){
 			if(meganeX8KData["renderResolutionMultiplierY"].is_number()){
 				newConfig.meganeX8K.renderResolutionMultiplierY = meganeX8KData["renderResolutionMultiplierY"].get<double>();
 			}
+			if(json& hiddenAreaJson = meganeX8KData["hiddenArea"]; hiddenAreaJson.is_object()){
+				auto& newHiddenArea = newConfig.meganeX8K.hiddenArea;
+				if(hiddenAreaJson["enable"].is_boolean()){ newHiddenArea.enable = hiddenAreaJson["enable"].get<bool>(); }
+				if(hiddenAreaJson["testMode"].is_boolean()){ newHiddenArea.testMode = hiddenAreaJson["testMode"].get<bool>(); }
+				if(hiddenAreaJson["detailLevel"].is_number()){ newHiddenArea.detailLevel = hiddenAreaJson["detailLevel"].get<int>(); }
+				if(hiddenAreaJson["radiusTopOuter"].is_number()){ newHiddenArea.radiusTopOuter = hiddenAreaJson["radiusTopOuter"].get<double>(); }
+				if(hiddenAreaJson["radiusTopInner"].is_number()){ newHiddenArea.radiusTopInner = hiddenAreaJson["radiusTopInner"].get<double>(); }
+				if(hiddenAreaJson["radiusBottomInner"].is_number()){ newHiddenArea.radiusBottomInner = hiddenAreaJson["radiusBottomInner"].get<double>(); }
+				if(hiddenAreaJson["radiusBottomOuter"].is_number()){ newHiddenArea.radiusBottomOuter = hiddenAreaJson["radiusBottomOuter"].get<double>(); }
+			}
 		}
 		// if(data["watchDistortionProfiles"].is_boolean()){
 		// 	newConfig.watchDistortionProfiles = data["watchDistortionProfiles"].get<bool>();
@@ -165,6 +175,15 @@ void ConfigLoader::WriteInfo(){
 				{"fovBurnInPrevention", defaultSettings.meganeX8K.fovBurnInPrevention},
 				{"renderResolutionMultiplierX", defaultSettings.meganeX8K.renderResolutionMultiplierX},
 				{"renderResolutionMultiplierY", defaultSettings.meganeX8K.renderResolutionMultiplierY},
+				{"hiddenArea", {
+					{"enable", defaultSettings.meganeX8K.hiddenArea.enable},
+					{"testMode", defaultSettings.meganeX8K.hiddenArea.testMode},
+					{"detailLevel", defaultSettings.meganeX8K.hiddenArea.detailLevel},
+					{"radiusTopOuter", defaultSettings.meganeX8K.hiddenArea.radiusTopOuter},
+					{"radiusTopInner", defaultSettings.meganeX8K.hiddenArea.radiusTopInner},
+					{"radiusBottomInner", defaultSettings.meganeX8K.hiddenArea.radiusBottomInner},
+					{"radiusBottomOuter", defaultSettings.meganeX8K.hiddenArea.radiusBottomOuter},
+				}},
 			}},
 			// {"watchDistortionProfiles", defaultSettings.watchDistortionProfiles}
 		}},

--- a/CustomHeadsetOpenVR/src/HiddenArea/HiddenArea.cpp
+++ b/CustomHeadsetOpenVR/src/HiddenArea/HiddenArea.cpp
@@ -1,0 +1,66 @@
+#include "HiddenArea.h"
+#include "../Config/Config.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+
+constexpr double kPi { 3.141592653589793 };
+
+std::vector<vr::HmdVector2_t> HiddenArea::CreateLineLoopMesh(vr::EVREye eye, const HiddenAreaMeshConfig& config)
+{
+	struct AreaCorner{
+		double x = 0.0;
+		double y = 0.0;
+		double radius = 0.0;
+	};
+
+	const int segments = 2 + std::clamp(config.detailLevel, 1, 32);
+	const bool testMode = config.testMode;
+
+	const double topOut = config.radiusTopOuter;
+	const double topIn  = config.radiusTopInner;
+	const double botIn  = config.radiusBottomInner;
+	const double botOut = config.radiusBottomOuter;
+	const bool isRight = (eye == vr::Eye_Right);
+	const double radNE = std::clamp(isRight ? topOut : topIn, 0.0, 0.5);
+	const double radNW = std::clamp(isRight ? topIn : topOut, 0.0, 0.5);
+	const double radSW = std::clamp(isRight ? botIn : botOut, 0.0, 0.5);
+	const double radSE = std::clamp(isRight ? botOut : botIn, 0.0, 0.5);
+
+	// Coordinates are a bit unusual since the display is rotated.
+	const std::array<const AreaCorner, 4> corners {
+		AreaCorner{ 1.0 - radNE, 1.0 - radNE, radNE }, // (1,1): NE Top Right
+		AreaCorner{ 0.0 + radNW, 1.0 - radNW, radNW }, // (0,1): NW Top Left
+		AreaCorner{ 0.0 + radSW, 0.0 + radSW, radSW }, // (0,0): SW Bottom Left
+		AreaCorner{ 1.0 - radSE, 0.0 + radSE, radSE }  // (1,0): SE Bottom Right
+	};
+
+	// Create the mesh
+	std::vector<vr::HmdVector2_t> mesh;
+	mesh.reserve(4 * segments + (testMode ? 4 : 0));
+
+	double baseAngle = 0.f;
+	const double angleIncr = kPi/(2.0 * (segments - 1));
+	for (const AreaCorner& corner : corners) {
+		for (int i = 0; i < segments; ++i) {
+			const double angle = baseAngle + (i * angleIncr);
+			mesh.push_back({
+				static_cast<float>(corner.x + corner.radius * std::cos(angle)),
+				static_cast<float>(corner.y + corner.radius * std::sin(angle))
+			});
+		}
+		baseAngle += (0.5 * kPi);
+	}
+
+	if (testMode) {
+		// Loop the mesh around the outside corners to invert the mesh (only the hidden area will be visible).
+		// This is a bit hacky and doesn't show up properly in the SteamVR VR view, but it does show in the HMD.
+		mesh.push_back({ 1.f, 0.f });
+		mesh.push_back({ 0.f, 0.f });
+		mesh.push_back({ 0.f, 1.f });
+		mesh.push_back({ 1.f, 1.f });
+	}
+
+	return mesh;
+}

--- a/CustomHeadsetOpenVR/src/HiddenArea/HiddenArea.h
+++ b/CustomHeadsetOpenVR/src/HiddenArea/HiddenArea.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "openvr_driver.h"
+#include <vector>
+
+struct HiddenAreaMeshConfig;
+
+namespace HiddenArea {
+	std::vector<vr::HmdVector2_t> CreateLineLoopMesh(vr::EVREye eye, const HiddenAreaMeshConfig& config);
+};

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To pull the latest changes, run `git pull --recurse-submodules`
 	- [X] Support for non square outputs to light edges of the display
 	- [ ] A near perfect default distortion profile
 	- [X] Multiple distortion profiles
-	- [ ] Hidden area mesh
+	- [X] Hidden area mesh
 - Config
 	- [ ] Define the structure of the config file
 	- [X] Create MeganeX section


### PR DESCRIPTION
Add the ability to set a hidden area mesh to cull the early-reject
pixels in the corners of the screen.

Features:
- Per-corner radius customization (but left and right-eye meshes are
  mirrors of one another).
- A "Test Mode", which renders only the hidden area and increases the
  black level to make it easy to see where it begins.

How to use:
1. Enable Hidden Area Meshes and enable the Test Mode.
2. Restart SteamVR. You should now see white sections in the corners
   of the HMD display.
3. Adjust the different radius options until you're happy with the
   size of the Hidden Area Mesh (you will need to restart SteamVR to
   see these changes).
4. Disable Test Mode and restart SteamVR one last time. The white area
   you configured in the previous steps will now be excluded from any
   rendering.

Impact on effective render resolution:
- 0.5 radius in all corners (a perfect circle) -> ~21% fewer pixels.
- 0.25 radius in all corners -> ~5% fewer pixels.

Notes:
- If your colors go weird after enabling hidden area meshes, then you
  might need to opt-in to the SteamVR Beta.
- Live reloading of settings is not supported, you do need to restart
  SteamVR for any changes to apply.
- The hidden area mesh might not show correctly in the SteamVR mirror.

## Examples:  

No hidden area mesh:  
![Off](https://github.com/user-attachments/assets/08f037ca-d83a-49d6-a73e-de92677b9ff6)

0.25 radius mesh on all corners:  
![Default25](https://github.com/user-attachments/assets/8d07d189-2d15-41bf-84bb-22e478cc1b66)   
0.25 radius mesh on all corners (test mode):  
![Default25Test](https://github.com/user-attachments/assets/9c94c384-d427-47e7-bed6-15b5922df834)

0.5 radius on inner corners:  
![Inner50](https://github.com/user-attachments/assets/cb48f14c-7fde-41d7-93ee-eeca74f41039)   
0.5 radius on inner corners (test mode):  
![Inner50Test](https://github.com/user-attachments/assets/3d628789-6914-48af-aa28-db2c2cea9abc)

All examples used 100°/96° horizontal/vertical FoV. The radius settings are in UV coordinates, so they scale with whatever resolution/FoV you use.