### PR TITLE
Add FOV/overlap calculations and burn-in note to headset settings

### DIFF
--- a/CustomHeadsetGUI/src/app/pages/devices/headset-settings/headset-settings.component.html
+++ b/CustomHeadsetGUI/src/app/pages/devices/headset-settings/headset-settings.component.html
@@ -141,6 +141,9 @@
                   <span i18n>Current rendered per eye FOV</span>
                   <span>&nbsp;:&nbsp;</span>
                   <span>{{res.fovX.toFixed(1)}}x{{res.fovY.toFixed(1)}}</span>
+                  @if(showBurnInDeviationNote(res.fovMaxX, res.fovMaxY)) {
+                    <span i18n="@@currentRenderedFovBurnInNote">&nbsp;(deviates by a random value to reduce burn-in)</span>
+                  }
                 </p>
               }
               @if(res.fovMaxX) {
@@ -148,6 +151,16 @@
                   <span i18n>Maximum possible per eye FOV</span>
                   <span>&nbsp;:&nbsp;</span>
                   <span>{{res.fovMaxX.toFixed(1)}}x{{res.fovMaxY.toFixed(1)}}</span>
+                </p>
+                <p>
+                  <span i18n="@@combinedHfov">Combined HFOV</span>
+                  <span>&nbsp;:&nbsp;</span>
+                  <span>{{combinedHfov(res.fovX).toFixed(1)}}</span>
+                </p>
+                <p>
+                  <span i18n="@@binocularOverlap">Binocular overlap</span>
+                  <span>&nbsp;:&nbsp;</span>
+                  <span>{{binocularOverlap(res.fovX).toFixed(1)}}</span>
                 </p>
               }
               @if(res.renderResolution100PercentX) {

--- a/CustomHeadsetGUI/src/app/pages/devices/headset-settings/headset-settings.component.ts
+++ b/CustomHeadsetGUI/src/app/pages/devices/headset-settings/headset-settings.component.ts
@@ -111,4 +111,19 @@ export class HeadsetSettingsComponent extends DeviceConfigComponentBase<BaseHead
   scaledMaxFOV(originalFOV: number) {
     return Math.ceil(originalFOV / (this.settings?.fovZoom || 1));
   }
+
+  combinedHfov(horizontalFov: number) {
+    return Math.max(0, horizontalFov + (this.settings?.eyeRotation || 0) * 2);
+  }
+
+  binocularOverlap(horizontalFov: number) {
+    return Math.max(0, horizontalFov - (this.settings?.eyeRotation || 0) * 2);
+  }
+
+  showBurnInDeviationNote(maxPossibleFovX: number, maxPossibleFovY: number) {
+    if (!this.settings?.fovBurnInPrevention) {
+      return false;
+    }
+    return this.settings.maxFovX < maxPossibleFovX || this.settings.maxFovY < maxPossibleFovY;
+  }
 }

--- a/CustomHeadsetGUI/src/locale/messages.ja.xlf
+++ b/CustomHeadsetGUI/src/locale/messages.ja.xlf
@@ -322,6 +322,10 @@
         <source>Enable</source>
         <target state="translated">有効化</target>
       </trans-unit>
+      <trans-unit id="currentRenderedFovBurnInNote" datatype="html">
+        <source> (deviates by a random value to reduce burn-in)</source>
+        <target state="translated">（焼き付き軽減のためランダムな値だけ変動します）</target>
+      </trans-unit>
       <trans-unit id="4651117059363790056" datatype="html">
         <source>100% Render resolution for SteamVR</source>
         <target state="translated">SteamVR用レンダリング解像度100%</target>
@@ -329,6 +333,14 @@
       <trans-unit id="6195061204627290703" datatype="html">
         <source>Render resolution for 1:1 sample per panel pixel</source>
         <target state="translated">パネルピクセルあたり1:1サンプルのレンダリング解像度</target>
+      </trans-unit>
+      <trans-unit id="combinedHfov" datatype="html">
+        <source>Combined HFOV</source>
+        <target state="translated">Combined HFOV</target>
+      </trans-unit>
+      <trans-unit id="binocularOverlap" datatype="html">
+        <source>Binocular overlap</source>
+        <target state="translated">両眼オーバーラップ</target>
       </trans-unit>
       <trans-unit id="6190895239365336532" datatype="html">
         <source>Enable Hidden Area Meshes</source>

--- a/CustomHeadsetGUI/src/locale/messages.xlf
+++ b/CustomHeadsetGUI/src/locale/messages.xlf
@@ -242,11 +242,20 @@
       <trans-unit id="6150901173509410295" datatype="html">
         <source>Shiftall driver is also disabled</source>
       </trans-unit>
+      <trans-unit id="currentRenderedFovBurnInNote" datatype="html">
+        <source> (deviates by a random value to reduce burn-in)</source>
+      </trans-unit>
       <trans-unit id="4651117059363790056" datatype="html">
         <source>100% Render resolution for SteamVR</source>
       </trans-unit>
       <trans-unit id="6195061204627290703" datatype="html">
         <source>Render resolution for 1:1 sample per panel pixel</source>
+      </trans-unit>
+      <trans-unit id="combinedHfov" datatype="html">
+        <source>Combined HFOV</source>
+      </trans-unit>
+      <trans-unit id="binocularOverlap" datatype="html">
+        <source>Binocular overlap</source>
       </trans-unit>
       <trans-unit id="1201696567241717027" datatype="html">
         <source>Hidden Area Mesh Settings</source>

--- a/CustomHeadsetGUI/src/locale/messages.zh-Hant.xlf
+++ b/CustomHeadsetGUI/src/locale/messages.zh-Hant.xlf
@@ -322,6 +322,10 @@
         <source>Enable</source>
         <target state="translated">啟用</target>
       </trans-unit>
+      <trans-unit id="currentRenderedFovBurnInNote" datatype="html">
+        <source> (deviates by a random value to reduce burn-in)</source>
+        <target state="translated">（會因隨機值而偏移，以減少烙印）</target>
+      </trans-unit>
       <trans-unit id="4651117059363790056" datatype="html">
         <source>100% Render resolution for SteamVR</source>
         <target state="translated">SteamVR 的 100% 渲染解析度</target>
@@ -329,6 +333,14 @@
       <trans-unit id="6195061204627290703" datatype="html">
         <source>Render resolution for 1:1 sample per panel pixel</source>
         <target state="translated">每個面板像素 1:1 個取樣的渲染解析度</target>
+      </trans-unit>
+      <trans-unit id="combinedHfov" datatype="html">
+        <source>Combined HFOV</source>
+        <target state="translated">Combined HFOV</target>
+      </trans-unit>
+      <trans-unit id="binocularOverlap" datatype="html">
+        <source>Binocular overlap</source>
+        <target state="translated">雙眼重疊</target>
       </trans-unit>
       <trans-unit id="6190895239365336532" datatype="html">
         <source>Enable Hidden Area Meshes</source>


### PR DESCRIPTION
Use eye rotation value to calculate combined HFOV and binocular overlap numbers.

Display a special note when the user is limiting the FOV and burn-in protection adds a random value.