### PR TITLE
Disable hardware acceleration for WebView2 web UI

### DIFF
--- a/CustomHeadsetGUI/src-tauri/tauri.conf.json
+++ b/CustomHeadsetGUI/src-tauri/tauri.conf.json
@@ -21,7 +21,8 @@
         "resizable": true,
         "fullscreen": false,
         "maximizable": true,
-        "url": "en-US/index.html"
+        "url": "en-US/index.html",
+        "additionalBrowserArgs": "--disable-gpu"
       }
     ],
     "security": {


### PR DESCRIPTION
- disabling the hardware accelaration for the WebView2 UI saves around 45 mb of VRAM and had no negative impact from testing