### PR TITLE
Minimal add-on to enable Dream Air SLAM support.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,3 +18,6 @@
 [submodule "ThirdParty/zlib"]
 	path = ThirdParty/zlib
 	url = https://github.com/madler/zlib
+[submodule "ThirdParty/pvr"]
+	path = ThirdParty/pvr
+	url = https://github.com/mbucchia/PVR.git

--- a/CustomHeadsetOpenVR/CustomHeadsetOpenVR.vcxproj
+++ b/CustomHeadsetOpenVR/CustomHeadsetOpenVR.vcxproj
@@ -28,6 +28,7 @@
     <ClInclude Include="src\Driver\Hooking\Hooking.h" />
     <ClInclude Include="src\Driver\Hooking\InterfaceHookInjector.h" />
     <ClInclude Include="src\Headsets\MeganeX8K.h" />
+    <ClInclude Include="src\Helpers\PimaxCommon.h" />
     <ClInclude Include="src\HiddenArea\HiddenArea.h" />
   </ItemGroup>
   <ItemGroup>
@@ -63,6 +64,7 @@
     <ClCompile Include="src\Headsets\GenericHeadset.cpp" />
     <ClCompile Include="src\Helpers\DisplayHelper.cpp" />
     <ClCompile Include="src\Helpers\EyeTrackingOutput.cpp" />
+    <ClCompile Include="src\Helpers\PimaxCommon.cpp" />
     <ClCompile Include="src\Helpers\PimaxEyeTrackingBridge.cpp" />
     <ClCompile Include="src\HiddenArea\HiddenArea.cpp" />
   </ItemGroup>
@@ -130,7 +132,7 @@
     <OutDir>$(SolutionDir)output\$(ProjectName)\bin\win$(PlatformArchitecture)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)\ThirdParty\openvr\headers\;$(SolutionDir)\ThirdParty\json\include\;</IncludePath>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)\ThirdParty\openvr\headers\;$(SolutionDir)\ThirdParty\json\include\;$(SolutionDir)\ThirdParty\pvr\</IncludePath>
     <LibraryPath>$(SolutionDir)\ThirdParty\openvr\lib\win$(PlatformArchitecture);$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
     <TargetName>driver_$(ProjectName)</TargetName>
     <OutDir>$(SolutionDir)output\$(ProjectName)\bin\win$(PlatformArchitecture)\</OutDir>
@@ -142,7 +144,7 @@
     <OutDir>$(SolutionDir)output\$(ProjectName)\bin\win$(PlatformArchitecture)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)\ThirdParty\openvr\headers\;$(SolutionDir)\ThirdParty\json\include\;</IncludePath>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDir)\ThirdParty\openvr\headers\;$(SolutionDir)\ThirdParty\json\include\;$(SolutionDir)\ThirdParty\pvr\</IncludePath>
     <LibraryPath>$(SolutionDir)\ThirdParty\openvr\lib\win$(PlatformArchitecture);$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
     <TargetName>driver_$(ProjectName)</TargetName>
     <OutDir>$(SolutionDir)output\$(ProjectName)\bin\win$(PlatformArchitecture)\</OutDir>

--- a/CustomHeadsetOpenVR/CustomHeadsetOpenVR.vcxproj.filters
+++ b/CustomHeadsetOpenVR/CustomHeadsetOpenVR.vcxproj.filters
@@ -51,6 +51,9 @@
     <ClInclude Include="..\ThirdParty\zlib\zutil.h">
       <Filter>Source Files\zlib</Filter>
     </ClInclude>
+    <ClInclude Include="src\Helpers\PimaxCommon.h">
+      <Filter>Source Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\Driver\DeviceProvider.cpp">
@@ -146,10 +149,13 @@
     <ClCompile Include="src\Headsets\FakeHeadset.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="src\Headsets\Helpers\PimaxEyeTrackingBridge.cpp">
+    <ClCompile Include="src\Helpers\EyeTrackingOutput.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="src\Headsets\Helpers\EyeTrackingOutput.cpp">
+    <ClCompile Include="src\Helpers\PimaxEyeTrackingBridge.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\Helpers\PimaxCommon.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/CustomHeadsetOpenVR/src/Headsets/BaseHeadset.cpp
+++ b/CustomHeadsetOpenVR/src/Headsets/BaseHeadset.cpp
@@ -19,7 +19,7 @@ void BaseHeadsetShim::PosTrackedDeviceActivate(uint32_t &unObjectId, vr::EVRInit
 	
 	std::string lighthouseName = vr::VRProperties()->GetStringProperty(container, vr::Prop_SerialNumber_String);
 	std::string modelNumber = vr::VRProperties()->GetStringProperty(container, vr::Prop_ModelNumber_String);
-	DriverLog("headset id: %s", lighthouseName);
+	DriverLog("headset id: %s", lighthouseName.c_str());
 	DriverLog("headset model: %s", modelNumber.c_str());
 	if(!IsDesiredHeadset(modelNumber, container) && !GetConfig().forceEnable){
 		// deactivate shim if this is not the correct headset

--- a/CustomHeadsetOpenVR/src/Headsets/DreamAir.cpp
+++ b/CustomHeadsetOpenVR/src/Headsets/DreamAir.cpp
@@ -3,7 +3,7 @@
 
 bool DreamAirShim::IsDesiredHeadset(std::string model, vr::PropertyContainerHandle_t container){
 	std::string trackingSystem = vr::VRProperties()->GetStringProperty(container, vr::Prop_TrackingSystemName_String);
-	if(model == "Pimax Dream Air" && trackingSystem == "lighthouse"){
+	if(IsOpenPortEnabled() && (model == "Pimax Dream Air" || GetHmdInfo().ProductId == 0x0044) && (trackingSystem == "lighthouse" || trackingSystem == "aapvr")) {
 		return true;
 	}
 	return false;
@@ -19,6 +19,7 @@ Config::BaseHeadsetConfig& DreamAirShim::GetConfigOld(){
 
 
 void DreamAirShim::SubActivate(vr::PropertyContainerHandle_t container){
+	// TODO: Remove eye tracking bridge - aapvr driver already includes the code.
 	eyeTracking.eyeRotation = defaultDriverConfig.dreamAir.eyeRotation;
 	eyeTracking.enabled = GetConfig().enableEyeTracking;
 	eyeTracking.Initialize();

--- a/CustomHeadsetOpenVR/src/Headsets/DreamAir.h
+++ b/CustomHeadsetOpenVR/src/Headsets/DreamAir.h
@@ -1,8 +1,9 @@
 #pragma once
 #include "BaseHeadset.h"
+#include "../Helpers/PimaxCommon.h"
 #include "../Helpers/PimaxEyeTrackingBridge.h"
 
-class DreamAirShim : public BaseHeadsetShim{
+class DreamAirShim : public BaseHeadsetShim, public PimaxCommon{
 public:
 	// function that returns if this is a Dream Air headset
 	virtual bool IsDesiredHeadset(std::string model, vr::PropertyContainerHandle_t container) override;

--- a/CustomHeadsetOpenVR/src/Helpers/PimaxCommon.cpp
+++ b/CustomHeadsetOpenVR/src/Helpers/PimaxCommon.cpp
@@ -1,0 +1,19 @@
+#include "PimaxCommon.h"
+
+#include "../Driver/DriverLog.h"
+
+PimaxCommon::PimaxCommon() {
+	pvr_initialise(&pvr);
+	if (pvr_createSession(pvr, &session) == pvr_success) {
+		// Cache useful immutable state.
+		isOpenPortEnabled = pvr_getIntConfig(GetPvrSession(), "no_render", 0);
+		pvr_getHmdInfo(GetPvrSession(), &hmdInfo);
+		pvrHmdTrackingStyle trackingStyle = pvrHmdTrackingStyle_Unknown;
+		trackingStyle = (pvrHmdTrackingStyle)pvr_getTrackedDeviceIntProperty(
+			GetPvrSession(),
+			pvrTrackedDevice_HMD,
+			pvrTrackedDeviceProp_Prop_HmdTrackingStyle_Int,
+			pvrHmdTrackingStyle_Unknown);
+		DriverLog("Detected headset '%s' (%04x) with %s tracking", GetHmdInfo().ProductName, GetHmdInfo().ProductId, trackingStyle == pvrHmdTrackingStyle_InsideOutCameras ? "SLAM" : "Lighthouse");
+	}
+}

--- a/CustomHeadsetOpenVR/src/Helpers/PimaxCommon.h
+++ b/CustomHeadsetOpenVR/src/Helpers/PimaxCommon.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <PVR.h>
+#include <PVR_API.h>
+
+class PimaxCommon {
+public:
+	PimaxCommon();
+	virtual ~PimaxCommon() = default;
+
+protected:
+	pvrSessionHandle GetPvrSession() const { return session; };
+	bool IsOpenPortEnabled() const { return isOpenPortEnabled; }
+	pvrHmdInfo GetHmdInfo() const { return hmdInfo; };
+
+private:
+	pvrEnvHandle pvr = {};
+	pvrSessionHandle session = {};
+	bool isOpenPortEnabled = false;
+	pvrHmdInfo hmdInfo = {};
+};


### PR DESCRIPTION
I _believe_ this change enables initial support for the Dream Air SLAM edition with the upcoming Pimax OpenPort. This leverages the fact that CustomHeadsetOpenVR hooks nicely to `driver_aapvr` (which seems to run in a special mode with Pimax OpenPort) and therefore gets tracking for free.

I don't have a Dream Air to test with, however, I can test with my Crystal Super SLAM edition via a few tweaks to pretend to be a Dream Air.

I do this by:
- Altering the device ProductId to be 0x0044 (Dream Air). This lets me pass the test in `DreamAirShim::IsDesiredHeadset()`
- Using the following `Config`. This allows `vrcompositor` to properly see the display output.
   ```
   {
     "dreamAir": {
       "enable": true,
       "displayRotation": 0,
       "resolutionX": 3840,
       "resolutionY": 3744,
     }
   }
   ```

Now of course, in my testing, the distortion is incorrect, since I use your Dream Air Default distortion profile. But assuming that the Dream Air SLAM can use the same distortion as the Dream Air LH, this shouldn't be a problem.

What works:
- Headset tracking seems to be correct. Tracking origin is problematic, but I believe this can be resolved later.
- Crystal motion controllers tracking, buttons, haptics are all working.

What's broken:
- Eye tracking. There's a conflict between your bridge and what `driver_aapvr` does. I _believe_ we can remove your bridge and let `driver_aapvr` do the work, however this didn't seem to work in my initial testing (but perhaps my headset was misconfigured!).

This PR is meant to test the water on your interest. I have also been prototyping a version that does not rely at all on `driver_aapvr` and instead spawns its own HMD-class driver and get tracking through PVR, and allows to extend to more Pimax headsets: https://github.com/mbucchia/CustomHeadsetOpenVR/commit/98e47dce3c2a6e52febec6e4c7a49b57a4be1466. That version would give a lot more control on the tracking and remove `driver_aapvr` as a black box.

Of course, the distortion profiles are still an issue, and I haven't cracked yet how to use the PVR API to do that (WIP for that is here: https://github.com/mbucchia/CustomHeadsetOpenVR/commit/ac016b4ddbb5f4865809640d2eadebfed79772e5)

<img width="542" height="276" alt="image" src="https://github.com/user-attachments/assets/658a5631-83e6-4f08-a54b-9c2fbc6403fd" />
