### PR TITLE
Add support for Pimax P2, such as the Pimax 5K and 8K series.

### DIFF
--- a/CustomHeadsetOpenVR/CustomHeadsetOpenVR.vcxproj
+++ b/CustomHeadsetOpenVR/CustomHeadsetOpenVR.vcxproj
@@ -22,6 +22,7 @@
     <ClInclude Include="src\Config\Config.h" />
     <ClInclude Include="src\Distortion\DistortionProfile.h" />
     <ClInclude Include="src\Distortion\NoneDistortionProfile.h" />
+    <ClInclude Include="src\Distortion\PimaxDistortionProfile.h" />
     <ClInclude Include="src\Distortion\RadialBezierDistortionProfile.h" />
     <ClInclude Include="src\Driver\DeviceProvider.h" />
     <ClInclude Include="src\Driver\DeviceShim.h" />
@@ -50,6 +51,7 @@
     <ClCompile Include="src\Config\Config.cpp" />
     <ClCompile Include="src\Config\ConfigLoader.cpp" />
     <ClCompile Include="src\Distortion\DistortionProfileConstructor.cpp" />
+    <ClCompile Include="src\Distortion\PimaxDistortionProfile.cpp" />
     <ClCompile Include="src\Distortion\RadialBezierDistortionProfile.cpp" />
     <ClCompile Include="src\Driver\CompositorPlugin.cpp" />
     <ClCompile Include="src\Driver\DeviceProvider.cpp" />

--- a/CustomHeadsetOpenVR/CustomHeadsetOpenVR.vcxproj.filters
+++ b/CustomHeadsetOpenVR/CustomHeadsetOpenVR.vcxproj.filters
@@ -167,5 +167,8 @@
     <ClCompile Include="src\Helpers\PimaxCommon.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\Distortion\PimaxDistortionProfile.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/CustomHeadsetOpenVR/src/Distortion/DistortionProfileConstructor.cpp
+++ b/CustomHeadsetOpenVR/src/Distortion/DistortionProfileConstructor.cpp
@@ -1,5 +1,6 @@
 #include "DistortionProfileConstructor.h"
 #include "RadialBezierDistortionProfile.h"
+#include "PimaxDistortionProfile.h"
 #include <cmath>
 #include <map>
 
@@ -146,6 +147,16 @@ bool PopulateBuiltInDistortionProfiles(){
 	};
 	builtInDistortionProfiles[dreamAir.name] = dreamAir;
 	
+	DistortionProfileConfig pimaxBuiltin = {};
+	pimaxBuiltin.name = "Pimax Builtin";
+	pimaxBuiltin.device = "Pimax";
+	pimaxBuiltin.modifiedTime = 0;
+	pimaxBuiltin.description = "Distortion Profile retrieved from Pimax API.";
+	pimaxBuiltin.author = "Pimax";
+	pimaxBuiltin.creationDate = 0.0;
+	pimaxBuiltin.type = "Pimax";
+	builtInDistortionProfiles[pimaxBuiltin.name] = pimaxBuiltin;
+
 	return true;
 };
 // this is pretty much just an initializer so immediately call
@@ -207,7 +218,12 @@ bool DistortionProfileConstructor::LoadDistortionProfile(std::string name){
 		radialBezierProfile->offsetY = config.offsetY;
 		newProfile = radialBezierProfile;
 	}
-	
+	else if (config.type == "Pimax"){
+		DriverLog("Using Pimax PVR distortion function");
+		PimaxDistortionProfile* pimaxProfile = new PimaxDistortionProfile();
+		newProfile = pimaxProfile;
+	}
+
 	bool changed = false;
 	
 	if(newProfile != nullptr){

--- a/CustomHeadsetOpenVR/src/Distortion/PimaxDistortionProfile.cpp
+++ b/CustomHeadsetOpenVR/src/Distortion/PimaxDistortionProfile.cpp
@@ -1,0 +1,41 @@
+#include "PimaxDistortionProfile.h"
+#include <algorithm>
+
+#define NOMINMAX
+#include "../Helpers/PimaxCommon.h"
+
+void PimaxDistortionProfile::Initialize() {
+    pvr_getEyeRenderInfo(PimaxCommon::GetPvrSession(), pvrEye_Left, &eyeInfo[pvrEye_Left]);
+    pvr_getEyeRenderInfo(PimaxCommon::GetPvrSession(), pvrEye_Right, &eyeInfo[pvrEye_Right]);
+    pvr_getFovTextureSize(PimaxCommon::GetPvrSession(), pvrEye_Left, eyeInfo[pvrEye_Left].Fov, 1.f, &viewportSize);
+}
+
+void PimaxDistortionProfile::GetProjectionRaw(vr::EVREye eEye, float* pfLeft, float* pfRight, float* pfBottom, float* pfTop) {
+    *pfLeft = -eyeInfo[eEye].Fov.LeftTan;
+    *pfRight = eyeInfo[eEye].Fov.RightTan;
+    // Top and bottom are backwards per SteamVR documentation.
+    *pfTop = eyeInfo[eEye].Fov.DownTan;
+    *pfBottom = -eyeInfo[eEye].Fov.UpTan;
+}
+
+Point2D PimaxDistortionProfile::ComputeDistortion(vr::EVREye eEye, ColorChannel colorChannel, float fU, float fV) {
+    pvrVector2f outUV[3];
+
+    const float minResolution = (float)std::min(resolutionX, resolutionY);
+    fU = (fU * minResolution / (2.0f * resolutionY)) + 0.5f;
+    fV = (fV * minResolution / (2.0f * resolutionX)) + 0.5f;
+
+    pvr_getHmdDistortedUV(PimaxCommon::GetPvrSession(), (pvrEyeType)eEye, { fU, fV }, outUV);
+
+    float fX = (outUV[colorChannel].x - 0.5f) * 2.f;
+    float fY = (outUV[colorChannel].y - 0.5f) * 2.f;
+
+    return { fX, fY };
+}
+
+void PimaxDistortionProfile::GetRecommendedRenderTargetSize(uint32_t* pnWidth, uint32_t* pnHeight) {
+    *pnWidth = (uint32_t)viewportSize.w;
+    *pnWidth = (*pnWidth + 3) / 4 * 4;
+    *pnHeight = (uint32_t)viewportSize.h;
+    *pnHeight = (*pnHeight + 3) / 4 * 4;
+}

--- a/CustomHeadsetOpenVR/src/Distortion/PimaxDistortionProfile.h
+++ b/CustomHeadsetOpenVR/src/Distortion/PimaxDistortionProfile.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "DistortionProfile.h"
+
+#include <cstdint>
+#include <PVR.h>
+
+class PimaxDistortionProfile : public DistortionProfile {
+public:
+	virtual void Initialize() override;
+
+	virtual void GetProjectionRaw(vr::EVREye eEye, float* pfLeft, float* pfRight, float* pfBottom, float* pfTop) override;
+
+	virtual Point2D ComputeDistortion(vr::EVREye eEye, ColorChannel colorChannel, float fU, float fV) override;
+
+	virtual void GetRecommendedRenderTargetSize(uint32_t* pnWidth, uint32_t* pnHeight) override;
+
+private:
+	pvrEyeRenderInfo eyeInfo[pvrEye_Count] = {};
+	pvrSizei viewportSize = {};
+};

--- a/CustomHeadsetOpenVR/src/Driver/HidModifier.cpp
+++ b/CustomHeadsetOpenVR/src/Driver/HidModifier.cpp
@@ -1,6 +1,7 @@
 #include "HidModifier.h"
 #include "DriverLog.h"
 #include "../Config/ConfigLoader.h"
+#include "../Helpers/PimaxCommon.h"
 
 #include "../../../ThirdParty/minhook/include/MinHook.h"
 #include "../../../ThirdParty/zlib/zlib.h"
@@ -292,6 +293,15 @@ std::string HidModifier::ReadLighthouseConfig(HidDeviceInfo &info){
 			}},
 			{"direct_mode_edid_vid", 53826}, // PVR
 			// {"device_class", "controller"}, 
+		};
+		jsonOverrides["REF-HMD"] = {
+			{"device", {
+				{"eye_target_width_in_pixels",
+					driverConfig.dreamAir.resolutionX ? driverConfig.dreamAir.resolutionX : PimaxCommon::GetInfo().resolutionX},
+				{"eye_target_height_in_pixels",
+					driverConfig.dreamAir.resolutionY ? driverConfig.dreamAir.resolutionY : PimaxCommon::GetInfo().resolutionY},
+			}},
+			{"direct_mode_edid_vid", 53826}, // PVR
 		};
 	}
 	if(driverConfig.meganeX8K.enable){

--- a/CustomHeadsetOpenVR/src/Headsets/PimaxLighthouse.cpp
+++ b/CustomHeadsetOpenVR/src/Headsets/PimaxLighthouse.cpp
@@ -4,32 +4,56 @@
 
 bool PimaxLighthouseShim::IsDesiredHeadset(std::string model, vr::PropertyContainerHandle_t container){
 	std::string trackingSystem = vr::VRProperties()->GetStringProperty(container, vr::Prop_TrackingSystemName_String);
-	if(GetInfo().connected && model == "Pimax Dream Air" && trackingSystem == "lighthouse"){
+	if(GetInfo().connected && (model == "Pimax Dream Air" || model == "REF-HMD") && trackingSystem == "lighthouse"){
 		return true;
 	}
 	return false;
 }
 
 Config::BaseHeadsetConfig& PimaxLighthouseShim::GetConfig(){
-	return driverConfig.dreamAir;
+	// TODO: Add config categories for Crystal and P2.
+	switch (GetInfo().headsetType){
+	case DreamAir:
+	default:
+		return PatchConfig(driverConfig.dreamAir);
+	}
 }
 
 Config::BaseHeadsetConfig& PimaxLighthouseShim::GetConfigOld(){
-	return driverConfigOld.dreamAir;
+	// TODO: Add config categories for Crystal and P2.
+	switch (GetInfo().headsetType){
+	case DreamAir:
+	default:
+		return PatchConfig(driverConfigOld.dreamAir);
+	}
 }
 
-void PimaxLighthouseShim::SubActivate(vr::PropertyContainerHandle_t container){
-	if(HasEyeTracking()){
+void PimaxLighthouseShim::PosTrackedDeviceActivate(uint32_t& unObjectId, vr::EVRInitError& returnValue){
+	// We need to set this config value before UpdateSettings() runs.
+	// This is only necessary when using the PimaxDistortionProfile.
+	pvr_setIntConfig(GetPvrSession(), "view_rotation_fix", GetConfig().parallelProjection);
+
+	if (HasEyeTracking()) {
 		eyeTrackingOutput.Initialize();
 	}
+
+	returnValue = vr::VRInitError_None;
+	BaseHeadsetShim::PosTrackedDeviceActivate(unObjectId, returnValue);
 }
 
 void PimaxLighthouseShim::SubDeactivate(){
 	StopEyeTracking();
 }
 
-void PimaxLighthouseShim::SubRunFrame(){
-	if(CheckDeviceLost()){
+void PimaxLighthouseShim::RunFrame(){
+	// We need to set this config value before UpdateSettings() runs.
+	// This is only necessary when using the PimaxDistortionProfile.
+	pvr_setIntConfig(GetPvrSession(), "view_rotation_fix", GetConfig().parallelProjection);
+
+	BaseHeadsetShim::RunFrame();
+
+	// Make sure to run BaseHeadsetShim::RunFrame() for housekeeping before checking for lost connection.
+	if (CheckDeviceLost()) {
 		return;
 	}
 

--- a/CustomHeadsetOpenVR/src/Headsets/PimaxLighthouse.h
+++ b/CustomHeadsetOpenVR/src/Headsets/PimaxLighthouse.h
@@ -10,10 +10,10 @@ public:
 	virtual Config::BaseHeadsetConfig& GetConfig() override;
 	// function that returns the old config for this headset
 	virtual Config::BaseHeadsetConfig& GetConfigOld() override;
-	// start eye tracking
-	virtual void SubActivate(vr::PropertyContainerHandle_t container) override;
+	// set pvr config, start eye tracking
+	virtual void PosTrackedDeviceActivate(uint32_t& unObjectId, vr::EVRInitError& returnValue) override;
 	// stop eye tracking
 	virtual void SubDeactivate() override;
 	// run eye tracking
-	virtual void SubRunFrame() override;
+	virtual void RunFrame() override;
 };

--- a/CustomHeadsetOpenVR/src/Headsets/PimaxSlam.cpp
+++ b/CustomHeadsetOpenVR/src/Headsets/PimaxSlam.cpp
@@ -98,7 +98,7 @@ public:
 			vr::VRScalarType_Absolute,
 			vr::VRScalarUnits_NormalizedOneSided);
 		vr::VRProperties()->SetInt32Property(
-			container, vr::Prop_Axis1Type_Int32,vr::EVRControllerAxisType::k_eControllerAxis_Trigger);
+			container, vr::Prop_Axis1Type_Int32, vr::EVRControllerAxisType::k_eControllerAxis_Trigger);
 		vr::VRDriverInput()->CreateBooleanComponent(
 			container, "/input/trigger/click", &components[ComponentTriggerClick]);
 		vr::VRDriverInput()->CreateBooleanComponent(
@@ -337,11 +337,21 @@ bool PimaxSlamDriver::IsDesiredHeadset(std::string model, vr::PropertyContainerH
 }
 
 Config::BaseHeadsetConfig& PimaxSlamDriver::GetConfig() {
-	return driverConfig.dreamAir;
+	// TODO: Add config categories for Crystal and P2.
+	switch (GetInfo().headsetType) {
+	case DreamAir:
+	default:
+		return PatchConfig(driverConfig.dreamAir);
+	}
 }
 
 Config::BaseHeadsetConfig& PimaxSlamDriver::GetConfigOld() {
-	return driverConfigOld.dreamAir;
+	// TODO: Add config categories for Crystal and P2.
+	switch (GetInfo().headsetType) {
+	case DreamAir:
+	default:
+		return PatchConfig(driverConfigOld.dreamAir);
+	}
 }
 
 void PimaxSlamDriver::PosTrackedDeviceActivate(uint32_t& unObjectId, vr::EVRInitError& returnValue) {
@@ -357,6 +367,10 @@ void PimaxSlamDriver::PosTrackedDeviceActivate(uint32_t& unObjectId, vr::EVRInit
 	// SteamVR requires an input profile for features like eye tracking. Reuse a basic one.
 	vr::VRProperties()->SetStringProperty(container, vr::Prop_InputProfilePath_String, "{oculus}/input/rift_profile.json");
 
+	// We need to set this config value before UpdateSettings() runs.
+	// This is only necessary when using the PimaxDistortionProfile.
+	pvr_setIntConfig(GetPvrSession(), "view_rotation_fix", GetConfig().parallelProjection);
+
 	if (HasEyeTracking()) {
 		eyeTrackingOutput.Initialize();
 	}
@@ -369,7 +383,14 @@ void PimaxSlamDriver::SubDeactivate() {
 	StopEyeTracking();
 }
 
-void PimaxSlamDriver::SubRunFrame() {
+void PimaxSlamDriver::RunFrame() {
+	// We need to set this config value before UpdateSettings() runs.
+	// This is only necessary when using the PimaxDistortionProfile.
+	pvr_setIntConfig(GetPvrSession(), "view_rotation_fix", GetConfig().parallelProjection);
+
+	BaseHeadsetShim::RunFrame();
+
+	// Make sure to run BaseHeadsetShim::RunFrame() for housekeeping before checking for lost connection.
 	if (CheckDeviceLost()) {
 		return;
 	}
@@ -446,7 +467,8 @@ void PimaxSlamDriver::SubRunFrame() {
 	// Update eye tracking.
 	if (HasEyeTracking() && GetConfig().enableEyeTracking) {
 		StartEyeTracking();
-	} else {
+	}
+	else {
 		StopEyeTracking();
 	}
 	eyeTrackingOutput.ipd = (float)(GetConfig().ipd + GetConfig().ipdOffset);

--- a/CustomHeadsetOpenVR/src/Headsets/PimaxSlam.h
+++ b/CustomHeadsetOpenVR/src/Headsets/PimaxSlam.h
@@ -11,6 +11,6 @@ public:
 
 	virtual void PosTrackedDeviceActivate(uint32_t& unObjectId, vr::EVRInitError& returnValue) override;
 	virtual void SubDeactivate() override;
-	virtual void SubRunFrame() override;
+	virtual void RunFrame() override;
 	virtual void HandleEvent(const vr::VREvent_t& event) override;
 };

--- a/CustomHeadsetOpenVR/src/Helpers/PimaxCommon.cpp
+++ b/CustomHeadsetOpenVR/src/Helpers/PimaxCommon.cpp
@@ -31,10 +31,12 @@ static bool EnsurePvrSession() {
 
 		pvrHmdInfo info = {};
 		pvr_getHmdInfo(s_pvrSession, &info);
-		// TODO: Add other Pimax headsets here.
 		switch (info.ProductId) {
-		case 0x0044:
+		case 0x0044: // Dream Air
 			s_info.headsetType = DreamAir;
+			break;
+		case 0x0101: // Pimax 5K and 8K series (share the same ProductId)
+			s_info.headsetType = P2;
 			break;
 		default:
 			DriverLog("Detected headset '%s' (%04x) - not supported", info.ProductName, info.ProductId);
@@ -56,6 +58,18 @@ static bool EnsurePvrSession() {
 			s_info.useSlamTracking = trackingStyle == pvrHmdTrackingStyle_InsideOutCameras;
 
 			DriverLog("Detected headset '%s' (%04x) with %s tracking", info.ProductName, info.ProductId, s_info.useSlamTracking ? "SLAM" : "Lighthouse");
+
+			pvrDisplayInfo displayInfo = {};
+			pvr_getEyeDisplayInfo(s_pvrSession, pvrEye_Left, &displayInfo);
+			DriverLog("Panel Resolution: %ux%u (Orientation: %u deg)", displayInfo.width, displayInfo.height, displayInfo.eye_rotate * 90);
+			s_info.resolutionX = displayInfo.width / 2;
+			s_info.resolutionY = displayInfo.height;
+			pvrEyeRenderInfo eyeInfo[pvrEye_Count] = {};
+			pvr_getEyeRenderInfo(s_pvrSession, pvrEye_Left, &eyeInfo[pvrEye_Left]);
+			pvr_getEyeRenderInfo(s_pvrSession, pvrEye_Right, &eyeInfo[pvrEye_Right]);
+			const auto cantingAngle = PVR::Quatf{ eyeInfo[pvrEye_Left].HmdToEyePose.Orientation }.Angle(eyeInfo[pvrEye_Right].HmdToEyePose.Orientation) /
+				2.f;
+			DriverLog("Canting Angle: %.2f deg", cantingAngle * 180 / 3.1415926f);
 		}
 	}
 	return true;
@@ -81,6 +95,14 @@ PimaxCommon::PimaxCommon() {
 	hasEyeTracking = // Crystal OG, Crystal Super, Dream Air SE, Dream Air.
 		GetHmdInfo().ProductId == 0x0012 || GetHmdInfo().ProductId == 0x0040 ||
 		GetHmdInfo().ProductId == 0x0042 || GetHmdInfo().ProductId == 0x0044;
+}
+
+Config::BaseHeadsetConfig& PimaxCommon::PatchConfig(Config::BaseHeadsetConfig& config) {
+	if (config.resolutionX == 0 || config.resolutionY == 0) {
+		config.resolutionX = GetInfo().resolutionX;
+		config.resolutionY = GetInfo().resolutionY;
+	}
+	return config;
 }
 
 bool PimaxCommon::CheckDeviceLost() {

--- a/CustomHeadsetOpenVR/src/Helpers/PimaxCommon.h
+++ b/CustomHeadsetOpenVR/src/Helpers/PimaxCommon.h
@@ -22,10 +22,10 @@ public:
 	PimaxCommon();
 	virtual ~PimaxCommon() = default;
 	static PimaxInfo GetInfo();
-
-protected:
 	static pvrSessionHandle GetPvrSession();
 	static double GetPvrTime();
+
+protected:
 	pvrHmdInfo GetHmdInfo() const { return hmdInfo; };
 	bool HasEyeTracking() const { return hasEyeTracking; }
 

--- a/CustomHeadsetOpenVR/src/Helpers/PimaxCommon.h
+++ b/CustomHeadsetOpenVR/src/Helpers/PimaxCommon.h
@@ -1,4 +1,6 @@
 #pragma once
+#include "../Config/Config.h"
+
 #include <PVR.h>
 #include <PVR_API.h>
 #include <atomic>
@@ -7,6 +9,7 @@
 
 enum PimaxHeadsetType {
 	DreamAir = 0,
+	P2,
 
 	Invalid
 };
@@ -15,6 +18,8 @@ struct PimaxInfo {
 	bool connected = false;
 	PimaxHeadsetType headsetType = Invalid;
 	bool useSlamTracking = false;
+	uint32_t resolutionX = 0;
+	uint32_t resolutionY = 0;
 };
 
 class PimaxCommon {
@@ -28,6 +33,8 @@ public:
 protected:
 	pvrHmdInfo GetHmdInfo() const { return hmdInfo; };
 	bool HasEyeTracking() const { return hasEyeTracking; }
+
+	Config::BaseHeadsetConfig& PatchConfig(Config::BaseHeadsetConfig& config);
 
 	bool CheckDeviceLost();
 


### PR DESCRIPTION
Add support for older Pimax "P2" headsets (aka 5K and 8K series). Pulls the distortion map from PVR.

Tested with an 8K X with the following configuration:

```
"dreamAir": {
  "enable": true,
  "displayRotation": 0,
  "resolutionX": 0,
  "resolutionY": 0,
  "eyeRotation": 10,
  "parallelProjection": false,
  "distortionProfile": "Pimax Builtin",
  "distortionMeshResolution": 64
}
```

And with parallel projections:

```
"dreamAir": {
  "enable": true,
  "displayRotation": 0,
  "resolutionX": 0,
  "resolutionY": 0,
  "eyeRotation": 0,
  "parallelProjection": true,
  "distortionProfile": "Pimax Builtin",
  "distortionMeshResolution": 64
}
```

`resolutionX` and `resolutionY` to 0 enable auto-detection of the panel resolution via PVR, allowing to cover the wide range of P2 variants.