### PR TITLE
Fix the out-of-box experience with the Pimax P2 series.

### DIFF
--- a/CustomHeadsetOpenVR/src/Config/Config.h
+++ b/CustomHeadsetOpenVR/src/Config/Config.h
@@ -451,6 +451,7 @@ public:
 			headsetType = HeadsetType::Pimax5KSuper;
 			distortionProfile = "Pimax Builtin";
 			distortionProfileDeviceType = "Pimax5KSuper";
+			distortionMeshResolution = 64;
 			maxFovX = 100;
 			maxFovY = 90;
 			edidVendorId = 53826; // PVR
@@ -472,6 +473,7 @@ public:
 			headsetType = HeadsetType::Pimax5KPlus;
 			distortionProfile = "Pimax Builtin";
 			distortionProfileDeviceType = "Pimax5KPlus";
+			distortionMeshResolution = 64;
 			maxFovX = 100;
 			maxFovY = 90;
 			edidVendorId = 53826; // PVR
@@ -493,6 +495,7 @@ public:
 			headsetType = HeadsetType::Pimax8KX;
 			distortionProfile = "Pimax Builtin";
 			distortionProfileDeviceType = "Pimax8KX";
+			distortionMeshResolution = 64;
 			maxFovX = 100;
 			maxFovY = 90;
 			edidVendorId = 53826; // PVR
@@ -514,6 +517,7 @@ public:
 			headsetType = HeadsetType::Pimax8KPlus;
 			distortionProfile = "Pimax Builtin";
 			distortionProfileDeviceType = "Pimax8KPlus";
+			distortionMeshResolution = 64;
 			maxFovX = 100;
 			maxFovY = 90;
 			edidVendorId = 53826; // PVR
@@ -535,6 +539,7 @@ public:
 			headsetType = HeadsetType::PimaxArtisan;
 			distortionProfile = "Pimax Builtin";
 			distortionProfileDeviceType = "PimaxArtisan";
+			distortionMeshResolution = 64;
 			maxFovX = 100;
 			maxFovY = 90;
 			edidVendorId = 53826; // PVR

--- a/CustomHeadsetOpenVR/src/Distortion/PimaxDistortionProfile.cpp
+++ b/CustomHeadsetOpenVR/src/Distortion/PimaxDistortionProfile.cpp
@@ -4,18 +4,15 @@
 #define NOMINMAX
 #include "../Helpers/PimaxCommon.h"
 
-void PimaxDistortionProfile::Initialize() {
-    pvr_getEyeRenderInfo(PimaxCommon::GetPvrSession(), pvrEye_Left, &eyeInfo[pvrEye_Left]);
-    pvr_getEyeRenderInfo(PimaxCommon::GetPvrSession(), pvrEye_Right, &eyeInfo[pvrEye_Right]);
-    pvr_getFovTextureSize(PimaxCommon::GetPvrSession(), pvrEye_Left, eyeInfo[pvrEye_Left].Fov, 1.f, &viewportSize);
-}
-
 void PimaxDistortionProfile::GetProjectionRaw(vr::EVREye eEye, float* pfLeft, float* pfRight, float* pfBottom, float* pfTop) {
-    *pfLeft = -eyeInfo[eEye].Fov.LeftTan;
-    *pfRight = eyeInfo[eEye].Fov.RightTan;
+    pvrEyeRenderInfo eyeInfo = {};
+    pvr_getEyeRenderInfo(PimaxCommon::GetPvrSession(), eEye == vr::Eye_Left ? pvrEye_Left : pvrEye_Right, &eyeInfo);
+
+    *pfLeft = -eyeInfo.Fov.LeftTan;
+    *pfRight = eyeInfo.Fov.RightTan;
     // Top and bottom are backwards per SteamVR documentation.
-    *pfTop = eyeInfo[eEye].Fov.DownTan;
-    *pfBottom = -eyeInfo[eEye].Fov.UpTan;
+    *pfTop = eyeInfo.Fov.DownTan;
+    *pfBottom = -eyeInfo.Fov.UpTan;
 }
 
 Point2D PimaxDistortionProfile::ComputeDistortion(vr::EVREye eEye, ColorChannel colorChannel, float fU, float fV) {
@@ -34,6 +31,11 @@ Point2D PimaxDistortionProfile::ComputeDistortion(vr::EVREye eEye, ColorChannel 
 }
 
 void PimaxDistortionProfile::GetRecommendedRenderTargetSize(uint32_t* pnWidth, uint32_t* pnHeight) {
+    pvrEyeRenderInfo eyeInfo = {};
+    pvr_getEyeRenderInfo(PimaxCommon::GetPvrSession(), pvrEye_Left, &eyeInfo);
+    pvrSizei viewportSize = {};
+    pvr_getFovTextureSize(PimaxCommon::GetPvrSession(), pvrEye_Left, eyeInfo.Fov, 1.f, &viewportSize);
+
     *pnWidth = (uint32_t)viewportSize.w;
     *pnWidth = (*pnWidth + 3) / 4 * 4;
     *pnHeight = (uint32_t)viewportSize.h;

--- a/CustomHeadsetOpenVR/src/Distortion/PimaxDistortionProfile.h
+++ b/CustomHeadsetOpenVR/src/Distortion/PimaxDistortionProfile.h
@@ -6,15 +6,9 @@
 
 class PimaxDistortionProfile : public DistortionProfile {
 public:
-	virtual void Initialize() override;
-
 	virtual void GetProjectionRaw(vr::EVREye eEye, float* pfLeft, float* pfRight, float* pfBottom, float* pfTop) override;
 
 	virtual Point2D ComputeDistortion(vr::EVREye eEye, ColorChannel colorChannel, float fU, float fV) override;
 
 	virtual void GetRecommendedRenderTargetSize(uint32_t* pnWidth, uint32_t* pnHeight) override;
-
-private:
-	pvrEyeRenderInfo eyeInfo[pvrEye_Count] = {};
-	pvrSizei viewportSize = {};
 };

--- a/CustomHeadsetOpenVR/src/Helpers/PimaxCommon.cpp
+++ b/CustomHeadsetOpenVR/src/Helpers/PimaxCommon.cpp
@@ -122,6 +122,9 @@ Config::BaseHeadsetConfig& PimaxCommon::PatchConfig(Config::BaseHeadsetConfig& c
 		config.resolutionX = GetInfo().resolutionX;
 		config.resolutionY = GetInfo().resolutionY;
 	}
+	if (config.distortionProfile == "Pimax Builtin" && config.parallelProjection) {
+		config.eyeRotation = 0;
+	}
 	return config;
 }
 


### PR DESCRIPTION
Refine the default settings.
Correctly handle toggling parallel projection on the go.