### PR TITLE
Support right controller hamburger button on Pimax controller.

### DIFF
--- a/CustomHeadsetOpenVR/src/Headsets/PimaxSlam.cpp
+++ b/CustomHeadsetOpenVR/src/Headsets/PimaxSlam.cpp
@@ -136,10 +136,11 @@ public:
 		vr::VRDriverInput()->CreateBooleanComponent(
 			container, "/input/thumbrest/touch", &components[ComponentThumbrestTouch]);
 
-		if (isLeft) {
-			vr::VRDriverInput()->CreateBooleanComponent(
-				container, "/input/system/click", &components[ComponentMenu]);
-		}
+		// The input profile does not support the system button on the right hand, however it still appears to work
+		// in SteamVR to invoke the dashboard. It's a happy accident.
+		vr::VRDriverInput()->CreateBooleanComponent(
+			container, "/input/system/click", &components[ComponentMenu]);
+
 		vr::VRDriverInput()->CreateBooleanComponent(
 			container, isLeft ? "/input/y/click" : "/input/b/click", &components[ComponentButton1]);
 		vr::VRDriverInput()->CreateBooleanComponent(
@@ -234,10 +235,8 @@ public:
 				components[ComponentButton1Touch], inputState.HandTouches[side] & pvrButton_B, timeOffset);
 			vr::VRDriverInput()->UpdateBooleanComponent(
 				components[ComponentButton2Touch], inputState.HandTouches[side] & pvrButton_A, timeOffset);
-			if (side == 0) {
-				vr::VRDriverInput()->UpdateBooleanComponent(
-					components[ComponentMenu], inputState.HandButtons[side] & pvrButton_ApplicationMenu, timeOffset);
-			}
+			vr::VRDriverInput()->UpdateBooleanComponent(
+				components[ComponentMenu], inputState.HandButtons[side] & pvrButton_ApplicationMenu, timeOffset);
 
 			// Update the battery level.
 			const int batteryPercentage = pvr_getTrackedDeviceIntProperty(


### PR DESCRIPTION
The button is technically not part of the `touch_profile` interaction profile, but SteamVR is still honoring system events for it (such as showing/hiding the dashboard).