### PR TITLE
Forward scene app change to Pimax Play to begin injecting Pimax DFR.

### DIFF
--- a/CustomHeadsetOpenVR/src/Headsets/PimaxLighthouse.cpp
+++ b/CustomHeadsetOpenVR/src/Headsets/PimaxLighthouse.cpp
@@ -57,6 +57,15 @@ void PimaxLighthouseShim::RunFrame(){
 	eyeTrackingOutput.RunFrame();
 }
 
+void PimaxLighthouseShim::HandleEvent(const vr::VREvent_t& event){
+	switch (event.eventType) {
+	case vr::VREvent_SceneApplicationChanged:
+		// Signal Pimax Play to perform a MagicAttach (DFR injector) when a new scene app started.
+		pvr_setIntConfig(GetPvrSession(), "openvr_client_changed", event.data.process.pid);
+		break;
+	}
+}
+
 
 extern "C" {
 // cant be bothered, implement them here

--- a/CustomHeadsetOpenVR/src/Headsets/PimaxLighthouse.h
+++ b/CustomHeadsetOpenVR/src/Headsets/PimaxLighthouse.h
@@ -16,4 +16,6 @@ public:
 	virtual void SubDeactivate() override;
 	// run eye tracking
 	virtual void RunFrame() override;
+	// forward events
+	virtual void HandleEvent(const vr::VREvent_t& event) override;
 };

--- a/CustomHeadsetOpenVR/src/Headsets/PimaxSlam.cpp
+++ b/CustomHeadsetOpenVR/src/Headsets/PimaxSlam.cpp
@@ -456,6 +456,10 @@ void PimaxSlamDriver::HandleEvent(const vr::VREvent_t& event) {
 			}
 		}
 		break;
+	case vr::VREvent_SceneApplicationChanged:
+		// Signal Pimax Play to perform a MagicAttach (DFR injector) when a new scene app started.
+		pvr_setIntConfig(GetPvrSession(), "openvr_client_changed", event.data.process.pid);
+		break;
 	}
 }
 


### PR DESCRIPTION
This change effectively makes Pimax built-in foveated rendering (aka "Pimax Magic") work with the driver. Upon setting the appropriate config value in PVR, `pi_server` will trigger call to `MagicAttach` that will attempt injection into the target process.