### PR TITLE
Add support for camera passthrough on Pimax headsets.

### DIFF
--- a/CustomHeadsetOpenVR/DriverFiles/THIRD_PARTY
+++ b/CustomHeadsetOpenVR/DriverFiles/THIRD_PARTY
@@ -1,0 +1,30 @@
+openvr_camera_sim
+------------------
+
+Copyright (c) 2026, Rectus
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/CustomHeadsetOpenVR/src/Headsets/PimaxSlam.cpp
+++ b/CustomHeadsetOpenVR/src/Headsets/PimaxSlam.cpp
@@ -1,15 +1,49 @@
 #include "PimaxSlam.h"
 
 #include "../Helpers/EyeTrackingOutput.h"
+#include "../Helpers/vr_blockqueue.h"
 
 #include <DirectXMath.h>
 #include <filesystem>
 #include <memory>
 #include "nlohmann/json.hpp"
+#include <PVR_Math.h>
 #include <shared_mutex>
 
 // Matches driver_aapvr.
 static constexpr uint64_t k_UniverseId = 30;
+
+static inline vr::HmdMatrix34_t StoreHmdMatrix34(const PVR::Matrix4f& matrix) {
+	return { matrix.M[0][0],
+			matrix.M[0][1],
+			matrix.M[0][2],
+			matrix.M[0][3],
+			matrix.M[1][0],
+			matrix.M[1][1],
+			matrix.M[1][2],
+			matrix.M[1][3],
+			matrix.M[2][0],
+			matrix.M[2][1],
+			matrix.M[2][2],
+			matrix.M[2][3] };
+}
+
+static inline vr::HmdMatrix34_t StoreHmdMatrix34(const DirectX::XMMATRIX& matrix) {
+	DirectX::XMFLOAT4X3 temp;
+	DirectX::XMStoreFloat4x3(&temp, matrix);
+	return { temp.m[0][0],
+			temp.m[1][0],
+			temp.m[2][0],
+			temp.m[3][0],
+			temp.m[0][1],
+			temp.m[1][1],
+			temp.m[2][1],
+			temp.m[3][1],
+			temp.m[0][2],
+			temp.m[1][2],
+			temp.m[2][2],
+			temp.m[3][2] };
+}
 
 // A driver for Pimax Crystal controllers.
 class PimaxCrystalControllerDriver : public vr::ITrackedDeviceServerDriver {
@@ -335,8 +369,434 @@ private:
 	DirectX::XMMATRIX poseOffset = DirectX::XMMatrixIdentity();
 };
 
+// A driver for Pimax Video See Through (VST).
+// IVRCameraComponent is not officially documented.
+// See https://github.com/Rectus/openvr_camera_sim/blob/main/camera_component.cpp
+class PimaxCameraDriver : public vr::IVRCameraComponent {
+public:
+	PimaxCameraDriver() {
+		QueryPerformanceFrequency(&qpcFrequency);
+	}
+
+	void Activate(vr::TrackedDeviceIndex_t deviceIndex) {
+		const vr::PropertyContainerHandle_t container =
+			vr::VRProperties()->TrackedDeviceToPropertyContainer(deviceIndex);
+
+		numCameras = pvr_getVSTType(PimaxCommon::GetPvrSession()) == pvrVSTTypeStereo ? 2 : 1;
+		for (uint32_t i = 0; i < numCameras; i++) {
+			pvr_getVSTCameraIntrinsics(PimaxCommon::GetPvrSession(), i, &cameraResolutionWidth, &cameraResolutionHeight, &focalLength[i], &principalPoint[i]);
+			pvr_getVSTCameraExtrinsics(PimaxCommon::GetPvrSession(), i, &cameraToHmd[i]);
+			pvrVSTDistortionType distortionType = {};
+			pvr_getVSTCameraDistortionParams(PimaxCommon::GetPvrSession(), i, &distortionType, distortionParams[i]);
+		}
+
+		vr::VRProperties()->SetBoolProperty(container, vr::Prop_HasCamera_Bool, true);
+		vr::VRProperties()->SetStringProperty(container, vr::Prop_CameraFirmwareDescription_String, "Pimax VST");
+		vr::VRProperties()->SetInt32Property(container, vr::Prop_NumCameras_Int32, numCameras);
+		vr::VRProperties()->SetInt32Property(
+			container,
+			vr::Prop_CameraFrameLayout_Int32,
+			numCameras == 1
+			? vr::EVRTrackedCameraFrameLayout_Mono
+			: (vr::EVRTrackedCameraFrameLayout_Stereo | vr::EVRTrackedCameraFrameLayout_HorizontalLayout));
+		vr::VRProperties()->SetInt32Property(container, vr::Prop_CameraStreamFormat_Int32, vr::CVS_FORMAT_NV12);
+		vr::VRProperties()->SetBoolProperty(container, vr::Prop_CameraSupportsCompatibilityModes_Bool, false);
+		vr::VRProperties()->SetBoolProperty(container, vr::Prop_AllowCameraToggle_Bool, true);
+
+		std::vector<vr::HmdMatrix34_t> transforms;
+		for (uint32_t i = 0; i < numCameras; i++) {
+			transforms.push_back(StoreHmdMatrix34(PVR::Matrix4(PVR::Posef(cameraToHmd[i]))));
+		}
+		vr::VRProperties()->SetProperty(container,
+			vr::Prop_CameraToHeadTransform_Matrix34,
+			&transforms[0],
+			sizeof(vr::HmdMatrix34_t),
+			vr::k_unHmdMatrix34PropertyTag);
+		vr::VRProperties()->SetPropertyVector(
+			container, vr::Prop_CameraToHeadTransforms_Matrix34_Array, vr::k_unHmdMatrix34PropertyTag, &transforms);
+
+		std::vector<int32_t> distortionFunction;
+		distortionFunction.push_back((int32_t)vr::VRDistortionFunctionType_Extended_FTheta);
+		distortionFunction.push_back((int32_t)vr::VRDistortionFunctionType_Extended_FTheta);
+		vr::VRProperties()->SetPropertyVector(container,
+			vr::Prop_CameraDistortionFunction_Int32_Array,
+			vr::k_unInt32PropertyTag,
+			&distortionFunction);
+		std::vector<double> distortionCoeff;
+		for (uint32_t i = 0; i < numCameras; i++) {
+			for (uint32_t j = 0; j < std::size(distortionParams[0]); j++) {
+				distortionCoeff.push_back(distortionParams[i][j]);
+			}
+		}
+		vr::VRProperties()->SetPropertyVector(container,
+			vr::Prop_CameraDistortionCoefficients_Float_Array,
+			vr::k_unFloatPropertyTag,
+			&distortionCoeff);
+
+		{
+			uint32_t nFrameBufferDataSize = 0;
+			int nDefaultFrameQueueSize = 0;
+			vr::ECameraVideoStreamFormat nVideoStreamFormat = GetCameraVideoStreamFormat();
+			GetCameraFrameBufferingRequirements(&nDefaultFrameQueueSize, &nFrameBufferDataSize);
+			vr::VRBlockQueue()->Create(&cameraBlockQueue,
+				"/lighthouse/camera/raw_frames",
+				nFrameBufferDataSize,
+				512,
+				nDefaultFrameQueueSize,
+				0);
+			DriverLog("Camera Block Queue: %lld", cameraBlockQueue);
+
+			vr::VRPathsSet<UINT32>(
+				cameraBlockQueue, vr::k_pathCameraWidth, cameraResolutionWidth * numCameras, vr::k_unInt32PropertyTag);
+			vr::VRPathsSet<UINT32>(
+				cameraBlockQueue, vr::k_pathCameraHeight, cameraResolutionHeight, vr::k_unInt32PropertyTag);
+			vr::VRPathsSet<UINT32>(
+				cameraBlockQueue, vr::k_pathCameraFormat, nVideoStreamFormat, vr::k_unInt32PropertyTag);
+		}
+
+		// Force RoomView by faking firmware versions that will pass the checks in vrcompositor.
+		vr::VRProperties()->SetUint64Property(container, vr::Prop_FPGAVersion_Uint64, UINT64_MAX);
+		vr::VRProperties()->SetUint64Property(container, vr::Prop_FirmwareVersion_Uint64, UINT64_MAX);
+		vr::VRProperties()->SetUint64Property(container, vr::Prop_CameraFirmwareVersion_Uint64, UINT64_MAX);
+
+		vr::VRProperties()->SetBoolProperty(container, vr::Prop_SupportsRoomViewDepthProjection_Bool, false);
+		vr::VRProperties()->SetBoolProperty(container, vr::Prop_AllowLightSourceFrequency_Bool, false);
+		vr::VRProperties()->SetBoolProperty(container, vr::Prop_Hmd_SupportsRoomViewDirect_Bool, false);
+		vr::VRProperties()->SetBoolProperty(container, vr::Prop_CameraSupportsCompatibilityModes_Bool, false);
+		vr::VRProperties()->SetInt32Property(container, vr::Prop_CameraCompatibilityMode_Int32, 0);
+		{
+			std::vector<float> CameraWhiteBalance;
+			CameraWhiteBalance.resize(8);
+			CameraWhiteBalance[0] = 1.0f;
+			CameraWhiteBalance[1] = 1.0f;
+			CameraWhiteBalance[2] = 1.0f;
+			CameraWhiteBalance[4] = 1.0f;
+			CameraWhiteBalance[5] = 1.0f;
+			CameraWhiteBalance[6] = 1.0f;
+			vr::VRProperties()->SetPropertyVector(container,
+				vr::Prop_CameraWhiteBalance_Vector4_Array,
+				vr::k_unHmdVector4PropertyTag,
+				&CameraWhiteBalance);
+		}
+	}
+
+	bool GetCameraFrameDimensions(vr::ECameraVideoStreamFormat nVideoStreamFormat, uint32_t* pWidth, uint32_t* pHeight) override {
+		bool status = false;
+		if (nVideoStreamFormat == vr::CVS_FORMAT_NV12 || nVideoStreamFormat == vr::CVS_FORMAT_UNKNOWN) {
+			*pWidth = cameraResolutionWidth * numCameras;
+			*pHeight = cameraResolutionHeight;
+			status = true;
+		}
+
+		return status;
+	}
+
+	bool GetCameraFrameBufferingRequirements(int* pDefaultFrameQueueSize, uint32_t* pFrameBufferDataSize) override {
+		// Assume NV12.
+		uint32_t nFrameBufferDataSize = (cameraResolutionWidth * cameraResolutionHeight * numCameras * 3) / 2;
+		nFrameBufferDataSize = sizeof(vr::CameraVideoStreamFrame_t) + nFrameBufferDataSize;
+		nFrameBufferDataSize = ((nFrameBufferDataSize + 15) / 16) * 16;
+		if (pDefaultFrameQueueSize) {
+			*pDefaultFrameQueueSize = 2;
+		}
+		if (pFrameBufferDataSize) {
+			*pFrameBufferDataSize = nFrameBufferDataSize;
+		}
+
+		return true;
+	}
+
+	bool SetCameraFrameBuffering(int nFrameBufferCount, void** ppFrameBuffers, uint32_t nFrameBufferDataSize) override {
+		bool status = false;
+		if (nFrameBufferCount == 0) {
+			cameraBuffer[0] = cameraBuffer[1] = nullptr;
+			status = true;
+		}
+		else if (nFrameBufferCount > 1) {
+			for (uint32_t i = 0; i < 2; i++) {
+				cameraBuffer[i] = (vr::CameraVideoStreamFrame_t*)ppFrameBuffers[i];
+				*cameraBuffer[i] = {};
+				cameraBuffer[i]->m_flFrameDeliveryRate = 1 / 30.0;
+				cameraBuffer[i]->m_nBufferCount = 2;
+				cameraBuffer[i]->m_nBufferIndex = (uint32_t)i;
+				cameraBuffer[i]->m_nWidth = cameraResolutionWidth * numCameras;
+				cameraBuffer[i]->m_nHeight = cameraResolutionHeight;
+				cameraBuffer[i]->m_nStreamFormat = vr::CVS_FORMAT_NV12;
+				cameraBuffer[i]->m_nImageDataSize =
+					(cameraResolutionWidth * cameraResolutionHeight * numCameras * 3) / 2;
+				cameraBuffer[i]->m_pImageData = (uint64_t)(cameraBuffer[i] + 1);
+				cameraBuffer[i]->m_RawTrackedDevicePose.bDeviceIsConnected = true;
+				cameraBuffer[i]->m_RawTrackedDevicePose.bPoseIsValid = false;
+				cameraBuffer[i]->m_RawTrackedDevicePose.mDeviceToAbsoluteTracking =
+					StoreHmdMatrix34(DirectX::XMMatrixIdentity());
+				cameraBuffer[i]->m_RawTrackedDevicePose.eTrackingResult = vr::TrackingResult_Running_OK;
+			}
+			status = true;
+		}
+
+		return status;
+	}
+
+	bool SetCameraVideoStreamFormat(vr::ECameraVideoStreamFormat nVideoStreamFormat) override {
+		bool status = false;
+		if (nVideoStreamFormat == vr::CVS_FORMAT_NV12) {
+			status = true;
+		}
+
+		return status;
+	}
+
+	vr::ECameraVideoStreamFormat GetCameraVideoStreamFormat() override {
+		return vr::CVS_FORMAT_NV12;
+	}
+
+	bool StartVideoStream() override {
+		QueryPerformanceCounter(&cameraStartTime);
+		cameraFrameIndex = 0;
+		cameraActive = true;
+		cameraPaused = false;
+
+		return true;
+	}
+
+	void StopVideoStream() override {
+		cameraActive = cameraPaused = false;
+	}
+
+	bool IsVideoStreamActive(bool* pbPaused, float* pflElapsedTime) override {
+		*pbPaused = cameraActive && cameraPaused;
+		LARGE_INTEGER now;
+		QueryPerformanceCounter(&now);
+		*pflElapsedTime =
+			cameraActive ? (now.QuadPart - cameraStartTime.QuadPart) / (float)qpcFrequency.QuadPart : 0.f;
+
+		return cameraActive;
+	}
+
+	const vr::CameraVideoStreamFrame_t* GetVideoStreamFrame() override {
+		// Not supported.
+		return nullptr;
+	}
+
+	void ReleaseVideoStreamFrame(const vr::CameraVideoStreamFrame_t* pFrameImage) override {
+	}
+
+	bool SetAutoExposure(bool bEnable) override {
+		// Not supported.
+		return false;
+	}
+
+	bool PauseVideoStream() override {
+		cameraPaused = true;
+		return true;
+	}
+
+	bool ResumeVideoStream() override {
+		cameraPaused = false;
+		return true;
+	}
+
+	bool GetCameraDistortion(uint32_t nCameraIndex, float flInputU, float flInputV, float* pflOutputU, float* pflOutputV) override {
+		// Taken as-is from https://github.com/Rectus/openvr_camera_sim/blob/main/camera_component.cpp
+		const double focalX = focalLength[nCameraIndex].x / (double)cameraResolutionWidth;
+		const double focalY = focalLength[nCameraIndex].y / (double)cameraResolutionHeight;
+
+		const double centerX = principalPoint[nCameraIndex].x / (double)cameraResolutionWidth - 0.5;
+		const double centerY = principalPoint[nCameraIndex].y / (double)cameraResolutionHeight - 0.5;
+
+		double UScaled = (flInputU - 0.5) * 2.0 / focalX;
+		double VScaled = (flInputV - 0.5) * 2.0 / focalY;
+
+		double radius = sqrt(UScaled * UScaled + VScaled * VScaled);
+
+		double theta = atan(radius);
+
+		double thetaD = theta + distortionParams[nCameraIndex][0] * pow(theta, 3) +
+			distortionParams[nCameraIndex][1] * pow(theta, 5) +
+			distortionParams[nCameraIndex][2] * pow(theta, 7) +
+			distortionParams[nCameraIndex][3] * pow(theta, 9);
+
+		double radialFactor = thetaD / radius;
+
+		*pflOutputU = (float)(UScaled * radialFactor * focalX + centerX + 0.5);
+		*pflOutputV = (float)(VScaled * radialFactor * focalY + centerY + 0.5);
+
+		return true;
+	}
+
+	bool GetCameraProjection(uint32_t nCameraIndex, vr::EVRTrackedCameraFrameType eFrameType, float flZNear, float flZFar, vr::HmdMatrix44_t* pProjection) override {
+		// Taken as-is from https://github.com/Rectus/openvr_camera_sim/blob/main/camera_component.cpp
+		*pProjection = {};
+		pProjection->m[0][0] = focalLength[nCameraIndex].x / (float)cameraResolutionWidth / 2.0f;
+		pProjection->m[1][1] = focalLength[nCameraIndex].y / (float)cameraResolutionHeight;
+		pProjection->m[0][2] = principalPoint[nCameraIndex].x / (float)cameraResolutionWidth;
+		pProjection->m[1][2] = principalPoint[nCameraIndex].y / (float)cameraResolutionHeight - 0.5f;
+		pProjection->m[2][2] = -flZFar / (flZFar - flZNear);
+		pProjection->m[2][3] = -flZFar * flZNear / (flZFar - flZNear);
+		pProjection->m[3][2] = -1;
+
+		return true;
+	}
+
+	bool SetFrameRate(int nISPFrameRate, int nSensorFrameRate) override {
+		// We cannot service this request. Pretend success.
+		return true;
+	}
+
+	bool SetCameraVideoSinkCallback(vr::ICameraVideoSinkCallback* pCameraVideoSinkCallback) override {
+		cameraSinkCallback = pCameraVideoSinkCallback;
+		return true;
+	}
+
+	bool GetCameraCompatibilityMode(vr::ECameraCompatibilityMode* pCameraCompatibilityMode) override {
+		*pCameraCompatibilityMode = vr::CAMERA_COMPAT_MODE_ISO_30FPS;
+		return true;
+	}
+
+	bool SetCameraCompatibilityMode(vr::ECameraCompatibilityMode nCameraCompatibilityMode) override {
+		bool status = false;
+		if (nCameraCompatibilityMode == vr::CAMERA_COMPAT_MODE_ISO_30FPS) {
+			status = true;
+		}
+
+		return status;
+	}
+
+	bool GetCameraFrameBounds(vr::EVRTrackedCameraFrameType eFrameType, uint32_t* pLeft, uint32_t* pTop, uint32_t* pWidth, uint32_t* pHeight) override {
+		*pLeft = *pTop = 0;
+		*pWidth = cameraResolutionWidth * numCameras;
+		*pHeight = cameraResolutionHeight;
+
+		return true;
+	}
+
+	bool GetCameraIntrinsics(uint32_t nCameraIndex, vr::EVRTrackedCameraFrameType eFrameType, vr::HmdVector2_t* pFocalLength, vr::HmdVector2_t* pCenter, vr::EVRDistortionFunctionType* peDistortionType, double rCoefficients[vr::k_unMaxDistortionFunctionParameters]) override {
+		(*pFocalLength).v[0] = focalLength[nCameraIndex].x;
+		(*pFocalLength).v[1] = focalLength[nCameraIndex].y;
+
+		(*pCenter).v[0] = principalPoint[nCameraIndex].x;
+		(*pCenter).v[1] = principalPoint[nCameraIndex].y;
+
+		*peDistortionType = vr::EVRDistortionFunctionType::VRDistortionFunctionType_FTheta;
+		for (uint32_t i = 0; i < std::size(distortionParams[0]); i++) {
+			rCoefficients[i] = distortionParams[nCameraIndex][i];
+		}
+
+		return true;
+	}
+
+	void RunFrame() {
+		if (cameraActive && !cameraPaused && cameraBuffer[cameraBufferIndex]) {
+			// Flip buffer.
+			cameraBufferIndex ^= 1;
+
+			// Retrieve and convert the image from PVR.
+			const uint32_t frameSize = (cameraResolutionWidth * cameraResolutionHeight * numCameras * 3) / 2;
+			pvrVSTStreamFrame frame = {};
+			pvr_getVSTStreamFrame(PimaxCommon::GetPvrSession(), pvrFrameIndex, &frame);
+			pvrFrameIndex = frame.frameIdx + 1;
+
+			switch (pvr_getVSTStreamFormat(PimaxCommon::GetPvrSession())) {
+			case pvrVST_FORMAT_RAW8:
+			{
+				uint8_t* y_plane = (uint8_t*)cameraBuffer[cameraBufferIndex]->m_pImageData;
+				memcpy((uint8_t*)cameraBuffer[cameraBufferIndex]->m_pImageData,
+					frame.buffer,
+					cameraResolutionWidth * cameraResolutionHeight * numCameras);
+				uint8_t* uv_plane = (uint8_t*)cameraBuffer[cameraBufferIndex]->m_pImageData +
+					cameraResolutionWidth * cameraResolutionHeight * numCameras;
+				memset(uv_plane, 128, (cameraResolutionWidth * cameraResolutionHeight * numCameras) / 2);
+			}
+			break;
+			case pvrVST_FORMAT_NV12:
+				memcpy((uint8_t*)cameraBuffer[cameraBufferIndex]->m_pImageData, frame.buffer, frameSize);
+				break;
+			}
+
+			// Push the frame to SteamVR.
+			LARGE_INTEGER now;
+			QueryPerformanceCounter(&now);
+			cameraBuffer[cameraBufferIndex]->m_flFrameElapsedTime =
+				(now.QuadPart - cameraStartTime.QuadPart) / (double)qpcFrequency.QuadPart;
+			cameraBuffer[cameraBufferIndex]->m_nFrameSequence = (uint32_t)cameraFrameIndex;
+
+			void* pvBuffer = nullptr;
+			vr::PropertyContainerHandle_t ulBlockContainer = 0;
+			const bool				acquired =
+				vr::VRBlockQueue()->AcquireWriteOnlyBlock(cameraBlockQueue, &ulBlockContainer, &pvBuffer) ==
+				vr::EBlockQueueError_BlockQueueError_None;
+			if (acquired) {
+				memcpy(pvBuffer, (void*)cameraBuffer[cameraBufferIndex]->m_pImageData, frameSize);
+				vr::VRPathsSet<UINT32>(
+					ulBlockContainer, vr::k_pathCameraFrameSize, frameSize, vr::k_unInt32PropertyTag);
+
+				vr::VRPathsSet<UINT64>(
+					ulBlockContainer, vr::k_pathCameraFrameSequence, cameraFrameIndex, vr::k_unUint64PropertyTag);
+
+				vr::VRPathsSet<double>(ulBlockContainer,
+					vr::k_pathCameraFrameTimeMonotonic,
+					now.QuadPart / (double)qpcFrequency.QuadPart,
+					vr::k_unDoublePropertyTag);
+				vr::VRPathsSet<UINT64>(ulBlockContainer,
+					vr::k_pathCameraFrameServerTimeTicks,
+					now.QuadPart,
+					vr::k_unUint64PropertyTag);
+				vr::VRPathsSet<double>(
+					ulBlockContainer, vr::k_pathCameraFrameDeliveryRate, 1 / 30.0, vr::k_unDoublePropertyTag);
+				vr::VRPathsSet<double>(ulBlockContainer,
+					vr::k_pathCameraFrameElapsedTime,
+					cameraBuffer[cameraBufferIndex]->m_flFrameElapsedTime,
+					vr::k_unDoublePropertyTag);
+
+				vr::VRBlockQueue()->ReleaseWriteOnlyBlock(cameraBlockQueue, ulBlockContainer);
+			}
+
+			cameraFrameIndex++;
+
+			if (cameraSinkCallback) {
+				cameraSinkCallback->OnCameraVideoSinkCallback();
+			}
+		}
+	}
+
+private:
+	LARGE_INTEGER qpcFrequency = {};
+
+	uint32_t numCameras = 0;
+	uint32_t cameraResolutionWidth = 0;
+	uint32_t cameraResolutionHeight = 0;
+	pvrVector2f focalLength[2] = {};
+	pvrVector2f principalPoint[2] = {};
+	pvrPosef cameraToHmd[2] = {};
+	float distortionParams[2][8] = {};
+
+	uint32_t pvrFrameIndex = 0;
+
+	vr::PropertyContainerHandle_t cameraBlockQueue = vr::k_ulInvalidPropertyContainer;
+	bool cameraActive = false;
+	bool cameraPaused = false;
+	LARGE_INTEGER cameraStartTime = {};
+	uint64_t cameraFrameIndex = 0;
+
+	vr::CameraVideoStreamFrame_t* cameraBuffer[2] = { nullptr, nullptr };
+	std::atomic<size_t> cameraBufferIndex = 1;
+	vr::ICameraVideoSinkCallback* cameraSinkCallback = nullptr;
+};
+
 static std::unique_ptr<PimaxCrystalControllerDriver> s_controllerDriver[2];
 static std::shared_mutex s_controllerDriverMutex;
+static std::unique_ptr<PimaxCameraDriver> s_cameraDriver;
+
+PimaxSlamDriver::PimaxSlamDriver() {
+	// Setting up the camera component must be done early, prior to any GetComponent().
+	const auto vstType = pvr_getVSTType(GetPvrSession());
+	if (vstType != pvrVSTTypeNone) {
+		const auto format = pvr_getVSTStreamFormat(GetPvrSession());
+		if (format == pvrVST_FORMAT_NV12 || format == pvrVST_FORMAT_RAW8) {
+			s_cameraDriver = std::make_unique<PimaxCameraDriver>();
+		}
+	}
+}
 
 bool PimaxSlamDriver::IsDesiredHeadset(std::string model, vr::PropertyContainerHandle_t container) {
 	return true;
@@ -348,6 +808,13 @@ Config::BaseHeadsetConfig& PimaxSlamDriver::GetConfig(){
 
 Config::BaseHeadsetConfig& PimaxSlamDriver::GetConfigOld(){
 	return GetHeadsetConfigOld();
+}
+
+void PimaxSlamDriver::PosTrackedDeviceGetComponent(const char*& pchComponentNameAndVersion, void*& returnComponent) {
+	BaseHeadsetShim::PosTrackedDeviceGetComponent(pchComponentNameAndVersion, returnComponent);
+	if (strcmp(pchComponentNameAndVersion, vr::IVRCameraComponent_Version) == 0 && s_cameraDriver) {
+		returnComponent = s_cameraDriver.get();
+	}
 }
 
 void PimaxSlamDriver::PosTrackedDeviceActivate(uint32_t& unObjectId, vr::EVRInitError& returnValue) {
@@ -378,6 +845,10 @@ void PimaxSlamDriver::PosTrackedDeviceActivate(uint32_t& unObjectId, vr::EVRInit
 
 	if (HasEyeTracking()) {
 		eyeTrackingOutput.Initialize();
+	}
+
+	if (s_cameraDriver) {
+		s_cameraDriver->Activate(unObjectId);
 	}
 
 	returnValue = vr::VRInitError_None;
@@ -492,6 +963,10 @@ void PimaxSlamDriver::RunFrame() {
 	}
 
 	PollMagicAttach();
+
+	if (s_cameraDriver) {
+		s_cameraDriver->RunFrame();
+	}
 }
 
 void PimaxSlamDriver::HandleEvent(const vr::VREvent_t& event) {

--- a/CustomHeadsetOpenVR/src/Headsets/PimaxSlam.h
+++ b/CustomHeadsetOpenVR/src/Headsets/PimaxSlam.h
@@ -6,11 +6,13 @@
 
 class PimaxSlamDriver : public BaseHeadsetShim, public PimaxCommon {
 public:
+	PimaxSlamDriver();
 	virtual bool IsDesiredHeadset(std::string model, vr::PropertyContainerHandle_t container) override;
 
 	virtual Config::BaseHeadsetConfig& GetConfig() override;
 	virtual Config::BaseHeadsetConfig& GetConfigOld() override;
 
+	virtual void PosTrackedDeviceGetComponent(const char*& pchComponentNameAndVersion, void*& returnComponent) override;
 	virtual void PosTrackedDeviceActivate(uint32_t& unObjectId, vr::EVRInitError& returnValue) override;
 	virtual void SubDeactivate() override;
 	virtual void RunFrame() override;

--- a/CustomHeadsetOpenVR/src/Helpers/vr_blockqueue.h
+++ b/CustomHeadsetOpenVR/src/Helpers/vr_blockqueue.h
@@ -1,0 +1,174 @@
+// Taken from https://github.com/Rectus/openvr_camera_sim/blob/main/camera_component.cpp
+// Added a couple of helpers at the bottom.
+
+// Converted to C++ from the OpenVR C API.
+
+#pragma once
+
+#ifndef _OPENVR_BLOCKQUEUE
+#define _OPENVR_BLOCKQUEUE
+
+#include "openvr_driver.h"
+
+namespace vr {
+    typedef uint64_t PathHandle_t;
+
+    struct PathWrite_t {
+        PathHandle_t ulPath;
+        enum EPropertyWriteType writeType;
+        enum ETrackedPropertyError eSetError;
+        void* pvBuffer;
+        uint32_t unBufferSize;
+        PropertyTypeTag_t unTag;
+        enum ETrackedPropertyError eError;
+        const char* pszPath;
+    };
+
+    struct PathRead_t {
+        PathHandle_t ulPath;
+        void* pvBuffer;
+        uint32_t unBufferSize;
+        PropertyTypeTag_t unTag;
+        uint32_t unRequiredBufferSize;
+        enum ETrackedPropertyError eError;
+        const char* pszPath;
+    };
+
+    typedef enum EBlockQueueError {
+        EBlockQueueError_BlockQueueError_None = 0,
+        EBlockQueueError_BlockQueueError_QueueAlreadyExists = 1,
+        EBlockQueueError_BlockQueueError_QueueNotFound = 2,
+        EBlockQueueError_BlockQueueError_BlockNotAvailable = 3,
+        EBlockQueueError_BlockQueueError_InvalidHandle = 4,
+        EBlockQueueError_BlockQueueError_InvalidParam = 5,
+        EBlockQueueError_BlockQueueError_ParamMismatch = 6,
+        EBlockQueueError_BlockQueueError_InternalError = 7,
+        EBlockQueueError_BlockQueueError_AlreadyInitialized = 8,
+        EBlockQueueError_BlockQueueError_OperationIsServerOnly = 9,
+        EBlockQueueError_BlockQueueError_TooManyConnections = 10,
+    } EBlockQueueError;
+
+    typedef enum EBlockQueueReadType {
+        EBlockQueueReadType_BlockQueueRead_Latest = 0,
+        EBlockQueueReadType_BlockQueueRead_New = 1,
+        EBlockQueueReadType_BlockQueueRead_Next = 2,
+    } EBlockQueueReadType;
+
+    typedef enum EBlockQueueCreationFlag {
+        EBlockQueueCreationFlag_BlockQueueFlag_OwnerIsReader = 1,
+    } EBlockQueueCreationFlag;
+
+    class IVRPaths {
+      public:
+        virtual ETrackedPropertyError ReadPathBatch(PropertyContainerHandle_t ulRootHandle,
+                                                    PathRead_t* pBatch,
+                                                    uint32_t unBatchEntryCount) = 0;
+        virtual ETrackedPropertyError WritePathBatch(PropertyContainerHandle_t ulRootHandle,
+                                                     PathWrite_t* pBatch,
+                                                     uint32_t unBatchEntryCount) = 0;
+        virtual ETrackedPropertyError StringToHandle(PathHandle_t* pHandle, const char* pchPath) = 0;
+        virtual ETrackedPropertyError HandleToString(PathHandle_t pHandle,
+                                                     const char* pchBuffer,
+                                                     uint32_t unBufferSize,
+                                                     uint32_t* punBufferSizeUsed) = 0;
+    };
+
+    class IVRBlockQueue {
+      public:
+        virtual EBlockQueueError Create(PropertyContainerHandle_t* pulQueueHandle,
+                                        const char* pchPath,
+                                        uint32_t unBlockDataSize,
+                                        uint32_t unBlockHeaderSize,
+                                        uint32_t unBlockCount,
+                                        uint32_t unFlags) = 0;
+
+        virtual EBlockQueueError Connect(PropertyContainerHandle_t* pulQueueHandle, const char* pchPath) = 0;
+
+        virtual EBlockQueueError Destroy(PropertyContainerHandle_t ulQueueHandle) = 0;
+
+        virtual EBlockQueueError AcquireWriteOnlyBlock(PropertyContainerHandle_t ulQueueHandle,
+                                                       PropertyContainerHandle_t* pulBlockHandle,
+                                                       void** ppvBuffer) = 0;
+
+        virtual EBlockQueueError ReleaseWriteOnlyBlock(PropertyContainerHandle_t ulQueueHandle,
+                                                       PropertyContainerHandle_t ulBlockHandle) = 0;
+
+        virtual EBlockQueueError WaitAndAcquireReadOnlyBlock(PropertyContainerHandle_t ulQueueHandle,
+                                                             PropertyContainerHandle_t* pulBlockHandle,
+                                                             void** ppvBuffer,
+                                                             EBlockQueueReadType eReadType,
+                                                             uint32_t unTimeoutMs) = 0;
+
+        virtual EBlockQueueError AcquireReadOnlyBlock(PropertyContainerHandle_t ulQueueHandle,
+                                                      PropertyContainerHandle_t* pulBlockHandle,
+                                                      void** ppvBuffer,
+                                                      EBlockQueueReadType eReadType) = 0;
+
+        virtual EBlockQueueError ReleaseReadOnlyBlock(PropertyContainerHandle_t ulQueueHandle,
+                                                      PropertyContainerHandle_t ulBlockHandle) = 0;
+
+        virtual EBlockQueueError QueueHasReader(PropertyContainerHandle_t ulQueueHandle, bool* pbHasReaders) = 0;
+    };
+
+    static const char* IVRPaths_Version = "IVRPaths_001";
+    static const char* IVRBlockQueue_Version = "IVRBlockQueue_005";
+
+    static IVRPaths* _VRPaths() {
+        static IVRPaths* pPaths = nullptr;
+        if (pPaths == nullptr) {
+            EVRInitError eError;
+            pPaths = (IVRPaths*)VRDriverContext()->GetGenericInterface(IVRPaths_Version, &eError);
+        }
+        return pPaths;
+    }
+
+    static IVRBlockQueue* _VRBlockQueue() {
+        static IVRBlockQueue* pBlockQueue = nullptr;
+        if (pBlockQueue == nullptr) {
+            EVRInitError eError;
+            pBlockQueue = (IVRBlockQueue*)VRDriverContext()->GetGenericInterface(IVRBlockQueue_Version, &eError);
+        }
+        return pBlockQueue;
+    }
+
+    inline IVRPaths* VRPaths() {
+        return _VRPaths();
+    }
+    inline IVRBlockQueue* VRBlockQueue() {
+        return _VRBlockQueue();
+    }
+
+    typedef const char* CVRPathHandle;
+
+    static const CVRPathHandle k_pathCameraWidth("/width");
+    static const CVRPathHandle k_pathCameraHeight("/height");
+    static const CVRPathHandle k_pathCameraFormat("/format");
+    static const CVRPathHandle k_pathCameraFrameSequence("/frame_sequence");
+    static const CVRPathHandle k_pathCameraFrameSize("/frame_size");
+    static const CVRPathHandle k_pathCameraFrameTimeMonotonic("/frame_time_monotonic");
+    static const CVRPathHandle k_pathCameraFrameServerTimeTicks("/server_time_ticks");
+    static const CVRPathHandle k_pathCameraFrameDeliveryRate("/delivery_rate");
+    static const CVRPathHandle k_pathCameraFrameElapsedTime("/elapsed_time");
+
+    template <typename T>
+    ETrackedPropertyError
+    VRPathsSet(PropertyContainerHandle_t ulRootHandle, CVRPathHandle pszPath, T value, PropertyTypeTag_t unTag) {
+        PathWrite_t batch{};
+        batch.writeType = PropertyWrite_Set;
+        T typedValue = value;
+        batch.pvBuffer = &typedValue;
+        batch.unBufferSize = sizeof(T);
+        batch.unTag = unTag;
+        batch.pszPath = (char*)pszPath;
+
+        ETrackedPropertyError error = VRPaths()->WritePathBatch(ulRootHandle, &batch, 1);
+        if (error != TrackedProp_Success) {
+            return error;
+        }
+
+        return batch.eError;
+    }
+
+} // namespace vr
+
+#endif


### PR DESCRIPTION
Not quite ripe for merge. Caveats:

- Requires unreleased `pi_server` with fix for hang inside `pvr_getVSTStreamFormat()`.
- Upon disconnecting the USB of the headset, `pvr_getVSTStreamFormat()` will hang even with the fix (reported to Pimax).
- When using "Show camera on controllers", the camera needs 90 degrees rotation. This can be fixed by rotating the source image and also apply a similar rotation to the camera properties (in a future change).

Note: SteamVR requires proper room setup in order to display room view. An incorrect room setup (eg: upside-down room) will not do it.

With #54, double tap on the side of the headset will toggle room view.

Tested on Pimax Crystal Super.