### PR TITLE
Port buttons code to Pimax Lighthouse headsets.

### DIFF
--- a/CustomHeadsetOpenVR/src/Headsets/PimaxLighthouse.cpp
+++ b/CustomHeadsetOpenVR/src/Headsets/PimaxLighthouse.cpp
@@ -20,9 +20,18 @@ Config::BaseHeadsetConfig& PimaxLighthouseShim::GetConfigOld(){
 }
 
 void PimaxLighthouseShim::PosTrackedDeviceActivate(uint32_t& unObjectId, vr::EVRInitError& returnValue){
+	vr::PropertyContainerHandle_t container = vr::VRProperties()->TrackedDeviceToPropertyContainer(unObjectId);
+
 	// We need to set this config value before UpdateSettings() runs.
 	// This is only necessary when using the PimaxDistortionProfile.
 	pvr_setIntConfig(GetPvrSession(), "view_rotation_fix", GetConfig().parallelProjection);
+
+	vr::VRProperties()->SetStringProperty(
+		container, vr::Prop_InputProfilePath_String, ("{" + driverConfigLoader.info.driverName + "}/input/pimaxhmd_profile.json").c_str());
+	vr::VRDriverInput()->CreateBooleanComponent(
+		container, "/input/system/click", &inputComponents[ComponentSystemClick]);
+	vr::VRDriverInput()->CreateBooleanComponent(container, "/input/tap/click", &inputComponents[ComponentTap]);
+	vr::VRDriverInput()->CreateBooleanComponent(container, "/proximity", &inputComponents[ComponentPresence]);
 
 	if (HasEyeTracking()) {
 		eyeTrackingOutput.Initialize();
@@ -68,6 +77,17 @@ void PimaxLighthouseShim::RunFrame(){
 	}
 	eyeTrackingOutput.ipd = (float)(GetConfig().ipd + GetConfig().ipdOffset);
 	eyeTrackingOutput.RunFrame();
+
+	// Update proximity sensor.
+	pvrHmdStatus hmdStatus = {};
+	pvr_getHmdStatus(GetPvrSession(), &hmdStatus);
+	vr::VRDriverInput()->UpdateBooleanComponent(inputComponents[ComponentPresence], hmdStatus.HmdMounted, 0);
+
+	// Update the buttons state.
+	bool systemClick = false, doubleTap = false;
+	GetHmdButtonsState(systemClick, doubleTap);
+	vr::VRDriverInput()->UpdateBooleanComponent(inputComponents[ComponentSystemClick], systemClick, 0);
+	vr::VRDriverInput()->UpdateBooleanComponent(inputComponents[ComponentTap], doubleTap, 0);
 
 	// Update the battery level (Crystal OG).
 	const vr::PropertyContainerHandle_t container = vr::VRProperties()->TrackedDeviceToPropertyContainer(deviceIndex);

--- a/CustomHeadsetOpenVR/src/Headsets/PimaxLighthouse.h
+++ b/CustomHeadsetOpenVR/src/Headsets/PimaxLighthouse.h
@@ -18,4 +18,15 @@ public:
 	virtual void RunFrame() override;
 	// forward events
 	virtual void HandleEvent(const vr::VREvent_t& event) override;
+
+private:
+	enum InputComponents {
+		ComponentSystemClick,
+		ComponentTap,
+		ComponentPresence,
+
+		ComponentCount,
+	};
+
+	vr::VRInputComponentHandle_t inputComponents[ComponentCount] = {};
 };

--- a/CustomHeadsetOpenVR/src/Helpers/PimaxCommon.cpp
+++ b/CustomHeadsetOpenVR/src/Helpers/PimaxCommon.cpp
@@ -260,7 +260,7 @@ void PimaxCommon::GetHmdButtonsState(bool& systemButton, bool& doubleTap) {
 	const HmdButton hmdButtonsState = (HmdButton)pvr_getIntConfig(GetPvrSession(), "hmd_buttons", 0);
 	const auto isButtonPressed = [&hmdButtonsState](const HmdButton button) {
 		return (hmdButtonsState & button) == button;
-		};
+	};
 	systemButton = isButtonPressed(HmdButton::Button_VolumeUp) && isButtonPressed(HmdButton::Button_VolumeDown);
 	doubleTap = isButtonPressed(HmdButton::Button_DoubleTap);
 }


### PR DESCRIPTION
I am not able to test this change. I did check that `driver_lighthouse` does not set its own `Prop_InputProfilePath_String` and does not clash with the input components created. However my only Pimax lighthouse headset, the 8KX, doesn't seem to report buttons using the PVR int config. So in theory this change _should_ work as long as PVR API behaves the same on Crystal/Dream Air Lighthouse and SLAM.