### PR TITLE
Fix PVR API detection and Pimax SLAM status reporting

### DIFF
--- a/CustomHeadsetOpenVR/src/Headsets/BaseHeadset.cpp
+++ b/CustomHeadsetOpenVR/src/Headsets/BaseHeadset.cpp
@@ -39,7 +39,10 @@ void BaseHeadsetShim::PosTrackedDeviceActivate(uint32_t &unObjectId, vr::EVRInit
 	// it blackscreens and immediately crashes windows when changed at runtime for the MeganeX on nvidia
 	vr::VRProperties()->SetBoolProperty(container, vr::Prop_DisplaySupportsRuntimeFramerateChange_Bool, false);
 	
-	// vr::VRProperties()->SetFloatProperty(container, vr::Prop_DisplayFrequency_Float, 90.0f);
+	if(GetConfig().headsetType == Config::HeadsetType::DreamAir ||
+		GetConfig().headsetType == Config::HeadsetType::DreamAirSE){
+		vr::VRProperties()->SetFloatProperty(container, vr::Prop_DisplayFrequency_Float, 90.0f);
+	}
 	
 	// vr::VRProperties()->SetInt32Property(container, vr::Prop_EdidVendorID_Int32, 0xd222); // HVR htc vr
 	// vr::VRProperties()->SetInt32Property(container, vr::Prop_EdidProductID_Int32, 43521); // vive

--- a/CustomHeadsetOpenVR/src/Headsets/PimaxSlam.cpp
+++ b/CustomHeadsetOpenVR/src/Headsets/PimaxSlam.cpp
@@ -3,6 +3,7 @@
 #include "../Helpers/EyeTrackingOutput.h"
 
 #include <DirectXMath.h>
+#include <cmath>
 #include <filesystem>
 #include <memory>
 #include "nlohmann/json.hpp"
@@ -10,6 +11,25 @@
 
 // Matches driver_aapvr.
 static constexpr uint64_t k_UniverseId = 30;
+
+static bool HasUsablePvrPose(const pvrPoseStatef& poseState) {
+	const auto& pose = poseState.ThePose;
+	const float quatNorm =
+		pose.Orientation.x * pose.Orientation.x +
+		pose.Orientation.y * pose.Orientation.y +
+		pose.Orientation.z * pose.Orientation.z +
+		pose.Orientation.w * pose.Orientation.w;
+	return poseState.TimeInSeconds > 0 &&
+		std::isfinite(pose.Position.x) &&
+		std::isfinite(pose.Position.y) &&
+		std::isfinite(pose.Position.z) &&
+		std::isfinite(pose.Orientation.x) &&
+		std::isfinite(pose.Orientation.y) &&
+		std::isfinite(pose.Orientation.z) &&
+		std::isfinite(pose.Orientation.w) &&
+		quatNorm > 0.5f &&
+		quatNorm < 1.5f;
+}
 
 // A driver for Pimax Crystal controllers.
 class PimaxCrystalControllerDriver : public vr::ITrackedDeviceServerDriver {
@@ -262,7 +282,10 @@ public:
 			pose.deviceIsConnected = isConnected;
 			pose.result = vr::TrackingResult_Running_OutOfRange;
 
-			if (isConnected) {
+			const bool hasUsablePose = HasUsablePvrPose(poseState);
+			isConnected = isConnected || hasUsablePose;
+			pose.deviceIsConnected = isConnected;
+			if ((poseState.StatusFlags & pvrStatus_OrientationTracked) || hasUsablePose) {
 				pose.vecPosition[0] = poseState.ThePose.Position.x;
 				pose.vecPosition[1] = poseState.ThePose.Position.y;
 				pose.vecPosition[2] = poseState.ThePose.Position.z;
@@ -363,6 +386,7 @@ void PimaxSlamDriver::PosTrackedDeviceActivate(uint32_t& unObjectId, vr::EVRInit
 
 	vr::VRProperties()->SetStringProperty(
 		container, vr::Prop_InputProfilePath_String, ("{" + driverConfigLoader.info.driverName + "}/input/pimaxhmd_profile.json").c_str());
+	vr::VRProperties()->SetBoolProperty(container, vr::Prop_ContainsProximitySensor_Bool, true);
 	vr::VRDriverInput()->CreateBooleanComponent(
 		container, "/input/system/click", &inputComponents[ComponentSystemClick]);
 	vr::VRDriverInput()->CreateBooleanComponent(container, "/input/tap/click", &inputComponents[ComponentTap]);
@@ -466,9 +490,11 @@ void PimaxSlamDriver::RunFrame() {
 
 	// Update proximity sensor.
 	pvrHmdStatus hmdStatus = {};
-	pvr_getHmdStatus(GetPvrSession(), &hmdStatus);
+	const pvrResult hmdStatusResult = pvr_getHmdStatus(GetPvrSession(), &hmdStatus);
+	const bool hmdPresent = hmdStatusResult == pvr_success && hmdStatus.HmdPresent && hmdStatus.ServiceReady && !hmdStatus.ShouldQuit;
+	const bool proximityActive = hmdPresent && (hmdStatus.HmdMounted || pvrHeadPoseUsable.load());
 	if(inputComponents[ComponentPresence]){
-		vr::VRDriverInput()->UpdateBooleanComponent(inputComponents[ComponentPresence], hmdStatus.HmdMounted, 0);
+		vr::VRDriverInput()->UpdateBooleanComponent(inputComponents[ComponentPresence], proximityActive, 0);
 	}
 
 	// Update the buttons state.
@@ -522,6 +548,7 @@ void PimaxSlamDriver::StopPvrTracking() {
 		pvrTrackingThread.join();
 		pvrTrackingThread = {};
 	}
+	pvrHeadPoseUsable = false;
 }
 
 void PimaxSlamDriver::PvrTrackingThread() {
@@ -540,7 +567,9 @@ void PimaxSlamDriver::PvrTrackingThread() {
 		const auto pvrNow = GetPvrTime();
 
 		pvrTrackingState trackingState = {};
-		pvr_getTrackingState(GetPvrSession(), pvrNow, &trackingState);
+		const pvrResult trackingResult = pvr_getTrackingState(GetPvrSession(), pvrNow, &trackingState);
+		const bool hasUsableHeadPose = trackingResult == pvr_success && HasUsablePvrPose(trackingState.HeadPose);
+		pvrHeadPoseUsable = hasUsableHeadPose;
 
 		// Update the headset pose.
 		{
@@ -548,7 +577,7 @@ void PimaxSlamDriver::PvrTrackingThread() {
 			pose.qWorldFromDriverRotation.w = pose.qDriverFromHeadRotation.w = pose.qRotation.w = 1.0;
 			pose.deviceIsConnected = true;
 			pose.result = vr::TrackingResult_Running_OutOfRange;
-			if (trackingState.HeadPose.StatusFlags & pvrStatus_OrientationTracked) {
+			if ((trackingState.HeadPose.StatusFlags & pvrStatus_OrientationTracked) || hasUsableHeadPose) {
 				pose.vecPosition[0] = trackingState.HeadPose.ThePose.Position.x;
 				pose.vecPosition[1] = trackingState.HeadPose.ThePose.Position.y;
 				pose.vecPosition[2] = trackingState.HeadPose.ThePose.Position.z;

--- a/CustomHeadsetOpenVR/src/Headsets/PimaxSlam.cpp
+++ b/CustomHeadsetOpenVR/src/Headsets/PimaxSlam.cpp
@@ -3,7 +3,6 @@
 #include "../Helpers/EyeTrackingOutput.h"
 
 #include <DirectXMath.h>
-#include <cmath>
 #include <filesystem>
 #include <memory>
 #include "nlohmann/json.hpp"
@@ -11,25 +10,6 @@
 
 // Matches driver_aapvr.
 static constexpr uint64_t k_UniverseId = 30;
-
-static bool HasUsablePvrPose(const pvrPoseStatef& poseState) {
-	const auto& pose = poseState.ThePose;
-	const float quatNorm =
-		pose.Orientation.x * pose.Orientation.x +
-		pose.Orientation.y * pose.Orientation.y +
-		pose.Orientation.z * pose.Orientation.z +
-		pose.Orientation.w * pose.Orientation.w;
-	return poseState.TimeInSeconds > 0 &&
-		std::isfinite(pose.Position.x) &&
-		std::isfinite(pose.Position.y) &&
-		std::isfinite(pose.Position.z) &&
-		std::isfinite(pose.Orientation.x) &&
-		std::isfinite(pose.Orientation.y) &&
-		std::isfinite(pose.Orientation.z) &&
-		std::isfinite(pose.Orientation.w) &&
-		quatNorm > 0.5f &&
-		quatNorm < 1.5f;
-}
 
 // A driver for Pimax Crystal controllers.
 class PimaxCrystalControllerDriver : public vr::ITrackedDeviceServerDriver {
@@ -282,10 +262,7 @@ public:
 			pose.deviceIsConnected = isConnected;
 			pose.result = vr::TrackingResult_Running_OutOfRange;
 
-			const bool hasUsablePose = HasUsablePvrPose(poseState);
-			isConnected = isConnected || hasUsablePose;
-			pose.deviceIsConnected = isConnected;
-			if ((poseState.StatusFlags & pvrStatus_OrientationTracked) || hasUsablePose) {
+			if (isConnected) {
 				pose.vecPosition[0] = poseState.ThePose.Position.x;
 				pose.vecPosition[1] = poseState.ThePose.Position.y;
 				pose.vecPosition[2] = poseState.ThePose.Position.z;
@@ -492,7 +469,7 @@ void PimaxSlamDriver::RunFrame() {
 	pvrHmdStatus hmdStatus = {};
 	const pvrResult hmdStatusResult = pvr_getHmdStatus(GetPvrSession(), &hmdStatus);
 	const bool hmdPresent = hmdStatusResult == pvr_success && hmdStatus.HmdPresent && hmdStatus.ServiceReady && !hmdStatus.ShouldQuit;
-	const bool proximityActive = hmdPresent && (hmdStatus.HmdMounted || pvrHeadPoseUsable.load());
+	const bool proximityActive = hmdPresent && hmdStatus.HmdMounted;
 	if(inputComponents[ComponentPresence]){
 		vr::VRDriverInput()->UpdateBooleanComponent(inputComponents[ComponentPresence], proximityActive, 0);
 	}
@@ -548,7 +525,6 @@ void PimaxSlamDriver::StopPvrTracking() {
 		pvrTrackingThread.join();
 		pvrTrackingThread = {};
 	}
-	pvrHeadPoseUsable = false;
 }
 
 void PimaxSlamDriver::PvrTrackingThread() {
@@ -567,9 +543,7 @@ void PimaxSlamDriver::PvrTrackingThread() {
 		const auto pvrNow = GetPvrTime();
 
 		pvrTrackingState trackingState = {};
-		const pvrResult trackingResult = pvr_getTrackingState(GetPvrSession(), pvrNow, &trackingState);
-		const bool hasUsableHeadPose = trackingResult == pvr_success && HasUsablePvrPose(trackingState.HeadPose);
-		pvrHeadPoseUsable = hasUsableHeadPose;
+		pvr_getTrackingState(GetPvrSession(), pvrNow, &trackingState);
 
 		// Update the headset pose.
 		{
@@ -577,7 +551,7 @@ void PimaxSlamDriver::PvrTrackingThread() {
 			pose.qWorldFromDriverRotation.w = pose.qDriverFromHeadRotation.w = pose.qRotation.w = 1.0;
 			pose.deviceIsConnected = true;
 			pose.result = vr::TrackingResult_Running_OutOfRange;
-			if ((trackingState.HeadPose.StatusFlags & pvrStatus_OrientationTracked) || hasUsableHeadPose) {
+			if (trackingState.HeadPose.StatusFlags & pvrStatus_OrientationTracked) {
 				pose.vecPosition[0] = trackingState.HeadPose.ThePose.Position.x;
 				pose.vecPosition[1] = trackingState.HeadPose.ThePose.Position.y;
 				pose.vecPosition[2] = trackingState.HeadPose.ThePose.Position.z;

--- a/CustomHeadsetOpenVR/src/Headsets/PimaxSlam.h
+++ b/CustomHeadsetOpenVR/src/Headsets/PimaxSlam.h
@@ -31,6 +31,7 @@ private:
 	void PvrTrackingThread();
 
 	std::thread pvrTrackingThread;
-	std::atomic<bool> pvrTrackingRunning;
+	std::atomic<bool> pvrTrackingRunning = false;
+	std::atomic<bool> pvrHeadPoseUsable = false;
 	vr::VRInputComponentHandle_t inputComponents[ComponentCount] = {};
 };

--- a/CustomHeadsetOpenVR/src/Headsets/PimaxSlam.h
+++ b/CustomHeadsetOpenVR/src/Headsets/PimaxSlam.h
@@ -32,6 +32,5 @@ private:
 
 	std::thread pvrTrackingThread;
 	std::atomic<bool> pvrTrackingRunning = false;
-	std::atomic<bool> pvrHeadPoseUsable = false;
 	vr::VRInputComponentHandle_t inputComponents[ComponentCount] = {};
 };

--- a/CustomHeadsetOpenVR/src/Helpers/AAPVRBlocker.cpp
+++ b/CustomHeadsetOpenVR/src/Helpers/AAPVRBlocker.cpp
@@ -3,8 +3,9 @@
 #include "../Config/ConfigLoader.h"
 
 
-#ifdef PVR_EXISTS
-	#include "C:/Program Files/Pimax/Sdk/Include/PVR_API.h"
+#if __has_include(<PVR_API.h>)
+	#define PVR_EXISTS
+	#include <PVR_API.h>
 #endif
 
 #include <windows.h>
@@ -245,11 +246,6 @@ void AAPVRLighthouseUnblockerRemoveHooks() {
 }
 
 
-#if __has_include("C:/Program Files/Pimax/Sdk/Include/PVR_API.h")
-	#define PVR_EXISTS
-	#include "C:/Program Files/Pimax/Sdk/Include/PVR_API.h"
-#endif
-
 bool AAPVRShouldBlock() {
 	if (sShouldBlockValid) {
 		return sShouldBlockCached;
@@ -275,6 +271,14 @@ bool AAPVRShouldBlock() {
 		return sShouldBlockCached;
 	}
 
+	pvrHmdInfo hmdInfo{};
+	pvr_getHmdInfo(sessionHandle, &hmdInfo);
+
+	const std::string productName = hmdInfo.ProductName;
+	const bool isDreamAir =
+		hmdInfo.ProductId == 0x0044 ||
+		ContainsInsensitive(productName, "Dream Air");
+
 	int noRender = pvr_getIntConfig(sessionHandle, "no_render", 0);
 	sShouldBlockCached = (noRender == 1);
 	
@@ -285,7 +289,12 @@ bool AAPVRShouldBlock() {
 	}
 	#endif
 
-	DriverLog("AAPVRBlocker: PVR no_render=%d, caching block=%d", noRender, sShouldBlockCached);
+	DriverLog("AAPVRBlocker: PVR headset='%s' product=0x%04x no_render=%d dream_air=%d, caching block=%d",
+		productName.c_str(),
+		hmdInfo.ProductId,
+		noRender,
+		isDreamAir,
+		sShouldBlockCached);
 #else
 	sShouldBlockCached = false;
 	sShouldBlockValid = true;


### PR DESCRIPTION
## Summary

- Build `AAPVRBlocker` against the repo-provided PVR headers instead of a machine-specific Pimax SDK path.
- Keep AAPVR blocking tied to actual PVR `no_render=1` and log the detected headset/product/no_render state.
- Report a proximity sensor for the Pimax SLAM HMD, using PVR's `HmdMounted` status only.
- Report 90 Hz only for Dream Air / Dream Air SE instead of applying that to every headset.

## Why

While testing a Dream Air / K11 with Pimax Play 2.0.2 and SteamVR 2.16.7, `AAPVRBlocker` was not compiling its PVR path on this machine because it checked a hard-coded `C:/Program Files/Pimax/Sdk/Include/PVR_API.h` path. The repo already has the PVR headers through `ThirdParty/pvr`, so checking for `<PVR_API.h>` lets the existing project include paths decide whether PVR support is available.

## Notes

This deliberately does not force-block `driver_aapvr` for Dream Air in normal Pimax mode. Local testing showed that blocking AAPVR while PVR `no_render=0` makes SteamVR fail with `VRInitError_Init_HmdNotFound`. The blocker remains gated by actual `no_render=1`.

This also deliberately keeps pose validity tied to PVR's tracking flags. It does not pass finite-but-unflagged poses to SteamVR, and it does not infer proximity from pose validity.

This also does not fix Pimax/NVIDIA direct-display enumeration failures. If Pimax has not exposed the headset display to the driver/runtime, CustomHeadsetOpenVR cannot recover that lower-level display path by itself.

Refs #58.

## Validation

- Built `CustomHeadsetOpenVR` `Release|x64` with MSBuild 18.5.3 after initializing submodules.
- Tested the same Pimax/SteamVR setup locally on Dream Air / Pimax Play 2.0.2.248 / SteamVR 2.16.7 before preparing this PR.
