### PR TITLE
Improvements to Pimax SLAM tracking.

### DIFF
--- a/CustomHeadsetOpenVR/src/Headsets/PimaxSlam.cpp
+++ b/CustomHeadsetOpenVR/src/Headsets/PimaxSlam.cpp
@@ -512,6 +512,11 @@ void PimaxSlamDriver::HandleEvent(const vr::VREvent_t& event) {
 
 void PimaxSlamDriver::StartPvrTracking() {
 	if (GetPvrSession() && !pvrTrackingRunning.exchange(true)) {
+		// Doing an auto-recenter is not ideal, but it's better than PVR spawning us in the middle of nowhere.
+		// Players tend to start from a similar location at every boot.
+		pvr_setTrackingOriginType(GetPvrSession(), pvrTrackingOrigin_FloorLevel);
+		pvr_recenterTrackingOrigin(GetPvrSession());
+
 		DriverLog("Starting PVR tracking thread");
 		pvrTrackingThread = std::thread(&PimaxSlamDriver::PvrTrackingThread, this);
 	}
@@ -526,6 +531,8 @@ void PimaxSlamDriver::StopPvrTracking() {
 }
 
 void PimaxSlamDriver::PvrTrackingThread() {
+	SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL);
+
 	const HANDLE timer = CreateWaitableTimer(nullptr, false, nullptr);
 	const LARGE_INTEGER noDelay = {};
 	// TODO: Make sure this is a reasonable value. 500Hz is quite high, but it doesn't seem to largely increase CPU/GPU utilization.


### PR DESCRIPTION
Some proposed "fixes", but really just wonky workarounds.

Pimax SLAM origin doesn't seem consistent across restarting `pi_server` no matter whether the Pimax Room Setup was run. In order to avoid being a mile high or upside-down, force a recenter upon connection to PVR. This of course doesn't ensure that you will start in the room at the correct position every time, but at least it gets you closer than before.

Also bump up the priority of the tracking thread. This might help with people who've seen stutters (and I guess they probably incorrectly mess around with process lasso or others).