### PR TITLE
Fix undefined behaviour and error handling in the HidModifier config path

### DIFF
--- a/CustomHeadsetOpenVR/src/Driver/HidModifier.cpp
+++ b/CustomHeadsetOpenVR/src/Driver/HidModifier.cpp
@@ -499,7 +499,10 @@ int HidModifier::HidGetFeatureReportHook(hid_device* device, unsigned char* data
 	#endif
 	
 	HidDeviceInfo &info = hidModifier.deviceMap[device];
-	if(info.newLighthouseConfig != nullptr){
+	// Both branches below read data[0] and write data[1], and the 0x10 branch also writes
+	// data[2]. length is a size_t, so a caller passing less than 2 would also underflow the
+	// (length - 2) that sizes the chunk copy, yielding a negative toCopy and a huge memcpy.
+	if(info.newLighthouseConfig != nullptr && length >= 3){
 		// output the new config
 		if(data[0] == 0x10){
 			// output new size


### PR DESCRIPTION
Three independent fixes in HidModifier, found while investigating a Dream Air that intermittently failed to enumerate. Each is a separate commit.

1. Uninitialised HidDeviceInfo members (e450067)
AddDevice default-initialises a HidDeviceInfo, so newLighthouseConfig, newLighthouseConfigLength and newLighthouseConfigOffset are indeterminate. ReadLighthouseConfig only assigns newLighthouseConfig on the path where it rewrites the config, so all three early returns — failed feature report, size > 20000, failed decompress — leave the pointer holding stack garbage. HidGetFeatureReportHook then tests it against nullptr and memcpys from it, and Delete() passes it to delete[].
This is reachable in practice: a driver log showing Failed to decompress lighthouse config was immediately followed by Driver lighthouse has no suitable devices and VRInitError_Init_HmdNotFound.

2. Failed recompression served anyway (b34102f)
compress() returning non-Z_OK was logged, but execution continued and assigned the partially written buffer to info.newLighthouseConfig. The hook then served that to driver_lighthouse in place of the device's own config, so a failed recompress produced a corrupt config rather than no change. Now the buffer is freed and newLighthouseConfig left null, so the hook passes through to the original.

3. Short-buffer guard in HidGetFeatureReportHook (03cb3a1)
The hook read data[0] and wrote data[1..2] without checking length. Since length is a size_t, a caller passing 0 or 1 also underflows the (length - 2) that sizes the chunk copy, giving a negative toCopy that memcpy takes as a huge value. driver_lighthouse supplies 65 in practice, so this is hardening rather than an observed fault.

Testing: all three compile clean on v143 / MSVC 14.44, Release x64. They have not been runtime-tested — I don't have HidModifierPrivate.cpp, so a local build isn't feature-equivalent to a release and wouldn't be a meaningful test. Happy to test a build if that's useful.